### PR TITLE
Changed attributes to properties

### DIFF
--- a/power-platform/alm/segmented-solutions-alm.md
+++ b/power-platform/alm/segmented-solutions-alm.md
@@ -40,7 +40,7 @@ adding an existing entity to the solution:
 
 -   **Include entity metadata**  This option includes no components&mdash;such as fields,
     forms, views, or related entities&mdash;but does include all the metadata
-    associated with the entity. Metadata includes the entity attributes, such as
+    associated with the entity. Metadata includes the entity properties, such as
     auditing, duplicate detection, and change tracking.
 
 -   **Include all components**  This option includes all components and metadata


### PR DESCRIPTION
Since 'attributes' is a word with a lot of history in this space (fields have been called attributes forever until now) it will easily confuse readers with statements like "Metadata includes the entity attributes".
Changing to properties for less risk of confusion.