### PR TITLE
Update Power Automate in PPAC disable

### DIFF
--- a/power-platform/admin/enable-embedded-flow-in-your-organization.md
+++ b/power-platform/admin/enable-embedded-flow-in-your-organization.md
@@ -50,7 +50,7 @@ Once the Power Automate integration feature is enabled, the following privileges
 
 2. Select **Settings** > **Product** > **Behavior**.   
   
-3. Under **Display behavior**, select **Show Power Automate on forms and in the site map** to Power Automate. Once enabled, this setting cannot be disabled again.
+3. Under **Display behavior**, select **Show Power Automate on forms and in the site map** to enable Power Automate. Once enabled, this setting cannot be disabled again.
 
 4. Select **Save**.
 

--- a/power-platform/admin/enable-embedded-flow-in-your-organization.md
+++ b/power-platform/admin/enable-embedded-flow-in-your-organization.md
@@ -41,16 +41,16 @@ Once the Power Automate integration feature is enabled, the following privileges
   
 - One or more flows created in the Power Automate environment to use with customer engagement apps. [!INCLUDE[proc_more_information](../includes/proc-more-information.md)] [Create a flow by using customer engagement apps](https://docs.microsoft.com/power-automate/connection-dynamics365)  
   
-## Enable or disable Power Automate in your organization  
+## Enable Power Automate in your organization  
  By default, all security roles allow users to run flows on the records that they have access to.  
   
- To enable or disable Power Automate integration in your organization, follow these steps.  
+ To enable Power Automate integration in your organization, follow these steps.  
 
 1. In the Power Platform admin center, select an environment. 
 
 2. Select **Settings** > **Product** > **Behavior**.   
   
-3. Under **Display behavior**, select **Show Power Automate on forms and in the site map** to enable or disable Power Automate.
+3. Under **Display behavior**, select **Show Power Automate on forms and in the site map** to Power Automate. Once enabled, this setting cannot be disabled again.
 
 4. Select **Save**.
 


### PR DESCRIPTION
We no longer allow disabling Power Automate once enabled. This documentation needs to be updated to reflect that.