### PR TITLE
Update setup-core-components.md

### DIFF
--- a/power-platform/guidance/coe/setup-core-components.md
+++ b/power-platform/guidance/coe/setup-core-components.md
@@ -76,6 +76,7 @@ This is the first step of the installation process and is required for every oth
         - Office 365 Outlook
         - Office 365 Groups
         - SharePoint
+        - Microsoft Teams
 
 1. On the left pane, select **Solutions**.
 


### PR DESCRIPTION
When importing the CentreOfExcellenceCoreComponents managed 2_0 solution I was asked to also setup a Microsoft Teams connection. I think it is missing from the unordered list in the import steps.