### PR TITLE
Correct grammar production for ‘IdentiferName’

### DIFF
--- a/power-platform/power-fx/expression-grammar.md
+++ b/power-platform/power-fx/expression-grammar.md
@@ -230,7 +230,7 @@ An *identifier* is a name used to refer to a value. Identifiers can either be re
 
 &emsp;&emsp;<a name="IdentifierName"></a>*IdentifierName* **:**<br>
 &emsp;&emsp;&emsp;&emsp;*[IdentifierStartCharacter](#IdentifierStartCharacter)*&emsp;*[IdentifierContinueCharacters](#IdentifierContinueCharacters)*<sub>opt</sub><br>
-&emsp;&emsp;&emsp;&emsp;*[SingleQuotedIdentifier](#SingleQuotedIdentifier)*<br>
+&emsp;&emsp;&emsp;&emsp;`'`&emsp;*[SingleQuotedIdentifier](#SingleQuotedIdentifier)*&emsp;`'`<br>
 
 &emsp;&emsp;<a name="IdentifierStartCharacter"></a>*IdentifierStartCharacter* **:**<br>
 &emsp;&emsp;&emsp;&emsp;*[LetterCharacter](#LetterCharacter)*<br>


### PR DESCRIPTION
The grammar production for ‘IdentifierName‘, specifically the second alternative ‘SingleQuotedIdentifier’, is missing the opening and closing ‘single quote’ (U+0027) tokens.

This is a correction to make that consistent with the syntax shown in the grammar production for ‘TextLiteral’.

(There may be further changes required in other files identified by a SME at a later date.)

_For a parallel change to the “[microsoft/PowerFX](https://github.com/microsoft/Power-Fx)” repository, see that repo’s [pull request #26](https://github.com/microsoft/Power-Fx/pull/26)._
 