### PR TITLE
Update powerapps-us-government gateway information.md

### DIFF
--- a/power-platform/admin/powerapps-us-government.md
+++ b/power-platform/admin/powerapps-us-government.md
@@ -225,7 +225,7 @@ Install an [on-premises data gateway](/powerapps/maker/canvas-apps/gateway-manag
 
 If your organization (tenant) has already configured and successfully connected the on-premises data gateway for Power BI US Government, then the process and configuration your organization executed to enable that will also enable on-premises connectivity for Power Apps. 
 
-Formerly, US Government customers had to contact support before configuring their first on-premises data gateway, as support would have to "whitelist" the tenant level for gateway use.  This is no longer necessary.  If you encounter any issues configuring or using the on-premises data gateway, you may contact support for assistance.
+Formerly, US Government customers needed to contact support before configuring their first on-premises data gateway, as support would need to "whitelist" the tenant for gateway use.  This is no longer necessary.  If you encounter any issues configuring or using the on-premises data gateway, you may contact support for assistance.
 
 ## Power Apps US Government feature limitations
 

--- a/power-platform/admin/powerapps-us-government.md
+++ b/power-platform/admin/powerapps-us-government.md
@@ -225,7 +225,7 @@ Install an [on-premises data gateway](/powerapps/maker/canvas-apps/gateway-manag
 
 If your organization (tenant) has already configured and successfully connected the on-premises data gateway for Power BI US Government, then the process and configuration your organization executed to enable that will also enable on-premises connectivity for Power Apps. 
 
-Formerly, US Government customers had to contact support before configuring their first on-premises data gateway, as support would have to enable gateway use at the tenant level.  This is no longer necessary.  If you encounter any issues configuring or using the on-premises data gateway, you may contact support for assistance.
+Formerly, US Government customers had to contact support before configuring their first on-premises data gateway, as support would have to "whitelist" the tenant level for gateway use.  This is no longer necessary.  If you encounter any issues configuring or using the on-premises data gateway, you may contact support for assistance.
 
 ## Power Apps US Government feature limitations
 

--- a/power-platform/admin/powerapps-us-government.md
+++ b/power-platform/admin/powerapps-us-government.md
@@ -223,7 +223,9 @@ The mobile application will now use the US Government Cloud domain.
 
 Install an [on-premises data gateway](/powerapps/maker/canvas-apps/gateway-management) to transfer data quickly and securely between a canvas app that's built in Power Apps and a data source that isn't in the cloud, such as an on-premises SQL Server database or an on-premises SharePoint site.
 
-If your organization (tenant) has already configured and successfully connected the on-premises data gateway for Power BI US Government, then the process and configuration your organization executed to enable that will also enable on-premises connectivity for Power Apps. However, if you are unable to connect to your tenant, you might need to go through a process to add your tenant to an approved list, which will enable this capability for your tenant. Should this occur, open a support ticket to address your needs. The support team will follow an established process to address your request.
+If your organization (tenant) has already configured and successfully connected the on-premises data gateway for Power BI US Government, then the process and configuration your organization executed to enable that will also enable on-premises connectivity for Power Apps. 
+
+Formerly, US Government customers had to contact support before configuring their first on-premises data gateway, as support would have to enable gateway use at the tenant level.  This is no longer necessary.  If you encounter any issues configuring or using the on-premises data gateway, you may contact support for assistance.
 
 ## Power Apps US Government feature limitations
 


### PR DESCRIPTION
Article references a gateway whitelisting process and advises customers to open a support case to have it done.  As far as I am aware (I'm in support) this is no longer necessary.

I am proposing a change to the gateway section to reflect this.  Alternatively, you could argue that the entire gateway section could be deleted as there really is no difference in this functionality between commercial and US Gov customers.