### PR TITLE
Update devops-build-tools.md

### DIFF
--- a/power-platform/alm/devops-build-tools.md
+++ b/power-platform/alm/devops-build-tools.md
@@ -41,6 +41,7 @@ that teams commonly put in place include Initiate, Export from Dev, Build, and R
 
 > [!NOTE] 
 > Microsoft Power Platform Build Tools are supported only for a Microsoft Dataverse environment with a database. More information: [Create an environment with a database](../admin/create-environment.md#create-an-environment-with-a-database)
+> Microsoft Power Platform Build Tools are currently not available for use in the **GCC** and **GCC High** regions. 
 
 ## What are Microsoft Power Platform Build Tools?
 


### PR DESCRIPTION
Per https://portal.microsofticm.com/imp/v3/incidents/details/236694659/home
The build tools are not supported in GCC region so we need to update the documentation to reflect this.