### PR TITLE
Update government-feature-availability.md

### DIFF
--- a/power-platform/admin/government-feature-availability.md
+++ b/power-platform/admin/government-feature-availability.md
@@ -35,6 +35,7 @@ There are certain experiences that are currently not available with Dynamics 365
 - [Relevance Search (Available CY2020-Q4)](/powerapps/user/relevance-search)
 - [Versium Predict](/dynamics365/customer-engagement/versium-predict/versium-predict)
 - [Teams Integration](/dynamics365/teams-integration/teams-integration)
+- [Microsoft Power Platform Build Tools for Azure DevOps](https://docs.microsoft.com/en-us/power-platform/alm/devops-build-tools)
 
 There are a number of other business application apps and services that are not currently available as a service operating within the GCC or GCC High at this time. They include:
 


### PR DESCRIPTION
PER 
https://portal.microsofticm.com/imp/v3/incidents/details/236694659/home
The Microsoft Power Platform Build Tools for Azure DevOps is not available for the GCC regions. Our documentation needs to support this indication. Related PR:
https://github.com/MicrosoftDocs/power-platform/pull/752