### PR TITLE
Update Recommendation on Pack Command

### DIFF
--- a/power-platform/alm/devops-build-tool-tasks.md
+++ b/power-platform/alm/devops-build-tool-tasks.md
@@ -357,8 +357,8 @@ steps:
 | Parameters       | Description     |
 |------------------|-----------------|
 | `SolutionOutputFile`<br/>Solution output file | (Required) The path and file name of the solution.zip file to pack the solution into. |
-| `SolutionSourceFolder`<br/>sSource folder of solution to pack | (Required) The path and source folder of the solution to pack. |
-| `SolutionType`<br/>Type of solution | (Required) The type of solution you want to pack. Options include: **Unmanaged** (recommended), **Managed**, and **Both**. |
+| `SolutionSourceFolder`<br/>Source folder of solution to pack | (Required) The path and source folder of the solution to pack. |
+| `SolutionType`<br/>Type of solution | (Required) The type of solution you want to pack. Options include: **Managed** (recommended), **Unmanaged**, and **Both**. |
 
 ### Power Platform Delete Solution
 


### PR DESCRIPTION
The pack command listed unmanaged as the recommended option. However, the managed should be the recommended as managed is what you'd use to deploy to downstream environments. Managed was also already listed in the sample above it. Also fixed a typo.