### PR TITLE
Custom retention policy Max Days Update

### DIFF
--- a/power-platform/admin/audit-data-user-activity.md
+++ b/power-platform/admin/audit-data-user-activity.md
@@ -69,7 +69,7 @@ This task requires the system administrator or customizer security role or equiv
    |      Setting |     Description    |
    |--------------------|---------------------|
    | Set the retention policy for these logs   | Default: 30 days.   |
-   | Set a custom retention policy | Maximum: 100,000 days  |  
+   | Set a custom retention policy | Maximum: 365,000 days  |  
 
    When new features are deployed, the audit retention period is set to **Forever** for all Dataverse environments with existing audit data. The default audit retention period is 30 days for new environments and existing environments without any audit data. You can also change the audit retention value using the [Dataverse Web API](/powerapps/developer/common-data-service/webapi/overview). 
 


### PR DESCRIPTION
Maximum custom retention policy for Audit that we can set is 365,000 days.

Verified in the 30 days Trial Online Environment.