### PR TITLE
Add note about using gateway and custom connectors

### DIFF
--- a/power-platform/admin/onpremises-data-gateway-management.md
+++ b/power-platform/admin/onpremises-data-gateway-management.md
@@ -113,6 +113,7 @@ For on-premises data gateways in standard mode, users can be added in any of the
 > - **Can Use** and **Can use + share** apply only to Power Apps and Power Automate. 
 > - While sharing gateways for **Can use** and **Can use + share** permission levels, you can restrict the data source type that the user can connect over the gateway. At least one data source type should be selected for the user to be successfully added.
 > - **Can Use** and **Can use + share** do not apply to custom connectors in Power Apps and Power Automate.
+> - The gateway must be shared with the **Admin** permission level to be used by custom connectors.
 
 > [!div class="mx-imgBorder"] 
 > ![Manage users.](media/manage-gateway-users.png "Manage users")


### PR DESCRIPTION
Adds missing documentation explaining that in order to use a Custom Connector with an On-premises Data Gateway, it needs to be shared with the Admin permission level.