### PR TITLE
The custom message for Administration is obsolete

### DIFF
--- a/power-platform/admin/admin-mode.md
+++ b/power-platform/admin/admin-mode.md
@@ -32,7 +32,6 @@ You can set a sandbox, production, or trial (subscription-based) environment in 
 |-------------|-----------------|  
 |Administration mode | Select to enable administration mode for the selected sandbox, production, or trial (subscription-based) environment. Only System Administrators or System Customizers will be able to sign in to the selected sandbox or production environment.|  
 |Background operations (optional) | Select to disable all asynchronous operations (see [Asynchronous service](/powerapps/developer/common-data-service/asynchronous-service)) such as workflows and synchronization with Exchange. Emails will not be sent and server-side synchronization for appointments, contacts, and tasks are disabled. **Note:**  Administration mode must be enabled to disable background operations.|  
-|Custom message (optional)| Enter a message that will be displayed to all users when they attempt to sign in.|  
   
 ## Set administration mode  
   
@@ -44,7 +43,9 @@ You can set a sandbox, production, or trial (subscription-based) environment in 
   
 4. Under **Administration mode**, toggle **Disabled** to **Enabled**.
 
-5. Optionally, you can set **Background operations** and **Custom message**, and then select **Save**.
+5. Optionally, you can set **Background operations**.
+
+6. Select **Save**.
 
 ## Known issues
 


### PR DESCRIPTION
It seems that the option for a custom message is now obsolete; the following message is shown:
"The Administration Mode custom message field is being removed. Edits to this field will no longer be allowed."