### PR TITLE
Correct name of app from "Environment Request" to "Maker - Environmen…

### DIFF
--- a/power-platform/guidance/coe/setup-environment-components.md
+++ b/power-platform/guidance/coe/setup-environment-components.md
@@ -56,7 +56,7 @@ There are several flows which will need to be turned on for these components:
 The environment request components consist of two apps:
 
 - [**Admin - Environment Requests**](core-components.md#admin---environment-requests) app for admins to view and approve environment and connectors requests. Share this app with other admins, and assign them the Power Platform Admin SR security role.
-- [**Environment Request**](core-components.md#environment-requests) app for makers to request environments and connectors. Share this app with your makers, and assign them the Power Platform Maker SR security role.
+- [**Maker - Environment Request**](core-components.md#environment-requests) app for makers to request environments and connectors. Share this app with your makers, and assign them the Power Platform Maker SR security role.
 
 More information:
 


### PR DESCRIPTION
…t Request" in coe/setup-environment-components.md

The correct name of the application is "Maker - Environment Request" not just "Environment Request". Correcting this will avoid the application being confused with the separate "Admin - Environment Request" application.