### PR TITLE
Update setup-almacceleratorpowerplatform-preview.md

### DIFF
--- a/power-platform/guidance/coe/setup-almacceleratorpowerplatform-preview.md
+++ b/power-platform/guidance/coe/setup-almacceleratorpowerplatform-preview.md
@@ -64,11 +64,12 @@ To complete the steps in this section, you'll need the following users and permi
 
 For the ALM Accelerator for Power Platform canvas app to work, the following connectors must be available to be used together in the environment into which the ALM accelerator is imported:
 
-- [Dataverse (legacy)](/connectors/commondataservice/)
+- [Dataverse (legacy)](https://learn.microsoft.com/en-us/connectors/commondataservice/)
+- HTTP
 - [Power Apps for Makers](/connectors/powerappsforappmakers/)
 - [HTTP with Azure AD](/connectors/webcontents/) (with endpoint access to <https://graph.microsoft.com>)
 - ALM Accelerator Custom DevOps (this connector will be created as part of the [accelerator solution import](#importing-the-solution-and-configuring-the-app))
-
+- [Office 365 Users](https://learn.microsoft.com/en-us/connectors/office365users/)
 ### Creator Kit
 
 The ALM Accelerator includes features that required the installation of the **Creator Kit** in the environment where you install ALM Accelerator for Power Platform.

--- a/power-platform/guidance/coe/setup-almacceleratorpowerplatform-preview.md
+++ b/power-platform/guidance/coe/setup-almacceleratorpowerplatform-preview.md
@@ -5,7 +5,7 @@ author: jenschristianschroder
 manager: devkeydet
 ms.component: pa-admin
 ms.topic: conceptual
-ms.date: 05/13/2022
+ms.date: 10/13/2022
 ms.subservice: guidance
 ms.author: jeschro
 ms.reviewer: jimholtz


### PR DESCRIPTION
Added HTTP and Office 365 Users connectors that I was finding needed to be in the DLP with the October release and fixed the links for the other connectors that were giving a GitHub 404. 

Cheers!
Andrew