### PR TITLE
Removed "State" from line 131

### DIFF
--- a/power-platform/guidance/coe/setup-core-components.md
+++ b/power-platform/guidance/coe/setup-core-components.md
@@ -128,7 +128,7 @@ The following flows support the inventory setup and need to be turned on before 
 - Command Center App >  Get M365 Service Messages
 - Command Center App > Initially Populate Bookmarks
 - Command Center App > Set CoE Flows State
-- Command Center App > Get CoE Flows State
+- Command Center App > Get CoE Flows
 - DLP Editor > Parse impacted resources into CSV
 
 


### PR DESCRIPTION
The word "State" is not part of the actual flow in CenterofExcellenceCoreComponents_3.53_managed.zip

![image](https://user-images.githubusercontent.com/64043240/197526582-e50a2eea-2848-4f08-923a-da0800df6a3f.png)

