### PR TITLE
Changed places of two lines for correct repro

### DIFF
--- a/power-platform/guidance/coe/setup-auditlog.md
+++ b/power-platform/guidance/coe/setup-auditlog.md
@@ -117,9 +117,10 @@ Now you'll configure and set up a custom connector that uses the [Office 365 Man
 
 1. Set the **Resource URL** to https://manage.office.com for a commercial tenant, https://manage-gcc.office.com for a GCC tenant, https://manage.office365.us for a GCC high tenant and https://manage.protection.apps.mil for a DoD tenant.
 
+1. Select **Update Connector**.
+
 1. Copy the **Redirect URL** into your text document in Notepad.
 
-1. Select **Update Connector**.
 
 > [!NOTE]
 > If you have a [data loss prevention (DLP) policy](../../admin/wp-data-loss-prevention.md) configured for your CoE Starter Kit environment, you'll need to add this connector to the business data&ndash;only group of this policy.


### PR DESCRIPTION
Changed "Copy the Redirect URL" to be on line 122 AFTER doing a connector update. The URL isn't available before the connector is updated since this is a new install.

Before:
![1-before updating CC](https://user-images.githubusercontent.com/64043240/198002688-34f0704e-305d-4221-8772-ce614453d5ab.png)

After:
![2-after updating CC](https://user-images.githubusercontent.com/64043240/198002733-5a60c2c5-a87f-4f9e-8529-b46d91af5279.png)
