### PR TITLE
Corrected typo where the word assess is misspelled

### DIFF
--- a/power-platform/admin/about-gdpr.md
+++ b/power-platform/admin/about-gdpr.md
@@ -46,7 +46,7 @@ Whether you’re a compliance officer, a decision-maker considering Dynamics 365
 
 Every journey needs a roadmap. Your roadmap to GDPR compliance begins with focusing on four key steps, and Microsoft Dynamics 365 provides robust tools and solutions for tackling each step. Learn more about how Microsoft products and services can help you on the road to GDPR compliance. 
 
-### Asses your organization
+### Assess your organization
 
 **Discover**
 


### PR DESCRIPTION
The word "assess" is spelled "asses" in the current version.