### PR TITLE
Minor tweak to improve clarity of usage of pac solution import parameter --activate-flows

### DIFF
--- a/power-platform/developer/cli/reference/solution.md
+++ b/power-platform/developer/cli/reference/solution.md
@@ -357,7 +357,7 @@ Import the solution into Dataverse.
 
 #### `--activate-flows` `-af`
 
-Turn on workflows specified in the deployment settings file using a specified user
+Turn on Dynamics 365 workflow processes that are specified in the deployment settings file using a specified user
 
 This parameter requires no value. It is a switch.
 


### PR DESCRIPTION
--activate-flows is used explicitly for enabling Dynamics 365 workflow processes NOT to be confused with Power Automate Cloud Flows. Updated the string to improve clarity.