### PR TITLE
update set-up-export-to-app-insights

### DIFF
--- a/power-platform/admin/set-up-export-application-insights.md
+++ b/power-platform/admin/set-up-export-application-insights.md
@@ -24,6 +24,7 @@ search.app:
 1. Ensure that you have an [Application Insights environment](/azure/azure-monitor/app/create-workspace-resource) set up for receiving the data, in addition to the [environment](environments-overview.md) that has a database. 
    - For the Application Insights environment, you must have contributor, writer, or admin rights.
    - The Application Insights environment must be unique for an environment or tenant. Note that Application Insights out-of-the-box reports won't function correctly if a single Application Insights environment contains data from multiple environments.
+   - (Optional) Ensure that the Resource group, the Application Insights Instance, and the dataverse environment are created in the same region. Telemetry data may not be visible in Application Insights if the environments differ.
 
 2. To set up data export in the [Power Platform admin center](https://admin.powerplatform.microsoft.com/) you'll need to be a member of the System Administrator role for an environment. 
 
@@ -86,6 +87,7 @@ search.app:
 |GCC-High     | No |  Fall 2022 |
 |GCC-DOD     | No |  TBD |
 |Mooncake     | No |  TBD |
+
 
 
 

--- a/power-platform/admin/set-up-export-application-insights.md
+++ b/power-platform/admin/set-up-export-application-insights.md
@@ -24,7 +24,7 @@ search.app:
 1. Ensure that you have an [Application Insights environment](/azure/azure-monitor/app/create-workspace-resource) set up for receiving the data, in addition to the [environment](environments-overview.md) that has a database. 
    - For the Application Insights environment, you must have contributor, writer, or admin rights.
    - The Application Insights environment must be unique for an environment or tenant. Note that Application Insights out-of-the-box reports won't function correctly if a single Application Insights environment contains data from multiple environments.
-   - (Optional) Ensure that the Resource group, the Application Insights Instance, and the dataverse environment are created in the same region. Telemetry data may not be visible in Application Insights if the environments differ.
+   - (Optional) Ensure that the resource group, the Application Insights instance, and the Power Platform environment are created in the same region. Telemetry data may not be visible in Application Insights if the environments differ.
 
 2. To set up data export in the [Power Platform admin center](https://admin.powerplatform.microsoft.com/) you'll need to be a member of the System Administrator role for an environment. 
 


### PR DESCRIPTION
inserted additional optional pre-req step. after some testing, we have found out that setting up the resource group, application insights and dataverse environments in different regions does not allow basic telemetry data such as dependencies or requests to show up in application insights. Only upon re-making them in the save region, does the basic telemetry data show up in application insights.