### PR TITLE
Update Power Platform DLP exempt resources doc

### DIFF
--- a/power-platform/admin/dlp-resource-exemption.md
+++ b/power-platform/admin/dlp-resource-exemption.md
@@ -24,8 +24,7 @@ search.app:
 
 # DLP resource exemption
 
-You can exempt apps and flows that you trust from DLP policies by using [DLP resource exemption PowerShell cmdlets](powerapps-powershell.md#dlp-resource-exemption-cmdlets). 
-
+You can define a list of exempted resources (canvas app, cloud flow, or chat bot) that will not be evaluated by a DLP policy by using [DLP resource exemption PowerShell cmdlets](powerapps-powershell.md#dlp-resource-exemption-cmdlets). You can exempt up to 2,000 low-code assets per DLP policy.
 
 
 

--- a/power-platform/admin/dlp-resource-exemption.md
+++ b/power-platform/admin/dlp-resource-exemption.md
@@ -1,14 +1,13 @@
 ---
 title: "Resource exemption  | MicrosoftDocs"
 description: Exempt apps and flows that you trust from DLP policies
-
 ms.component: pa-admin
 ms.topic: conceptual
 ms.date: 08/03/2021
 ms.subservice: admin
 author: mikferland-msft
 ms.author: miferlan
-ms.reviewer: jimholtz
+ms.reviewer: matp
 contributors:
   - mikferland-msft
   - mihaelablendea
@@ -24,7 +23,7 @@ search.app:
 
 # DLP resource exemption
 
-You can define a list of exempted resources (canvas app, cloud flow, desktop flow, or chat bot) that will not be evaluated by a DLP policy by using [DLP resource exemption PowerShell cmdlets](powerapps-powershell.md#dlp-resource-exemption-cmdlets). You can exempt up to 2,000 low-code resources per DLP policy.
+You can define a list of exempted resources (canvas app, cloud flow, desktop flow, or chatbot) that will not be evaluated by a DLP policy by using [DLP resource exemption PowerShell cmdlets](powerapps-powershell.md#dlp-resource-exemption-cmdlets). You can exempt up to 2,000 low-code resources per DLP policy.
 
 
 

--- a/power-platform/admin/dlp-resource-exemption.md
+++ b/power-platform/admin/dlp-resource-exemption.md
@@ -24,7 +24,7 @@ search.app:
 
 # DLP resource exemption
 
-You can define a list of exempted resources (canvas app, cloud flow, or chat bot) that will not be evaluated by a DLP policy by using [DLP resource exemption PowerShell cmdlets](powerapps-powershell.md#dlp-resource-exemption-cmdlets). You can exempt up to 2,000 low-code assets per DLP policy.
+You can define a list of exempted resources (canvas app, cloud flow, desktop flow, or chat bot) that will not be evaluated by a DLP policy by using [DLP resource exemption PowerShell cmdlets](powerapps-powershell.md#dlp-resource-exemption-cmdlets). You can exempt up to 2,000 low-code resources per DLP policy.
 
 
 


### PR DESCRIPTION
Update the documentation to clarify that up to 2,000 resources can be exempted from a Power Platform DLP policy. Plus, minor wording changes suggested by Mik.