### PR TITLE
Fixed issue with Install-Module command.

### DIFF
--- a/power-platform/guidance/coe/setup-almacceleratorpowerplatform-preview.md
+++ b/power-platform/guidance/coe/setup-almacceleratorpowerplatform-preview.md
@@ -147,7 +147,7 @@ In order for the pipelines to perform certain actions against the environments (
 > [!IMPORTANT]
 > Currently this cmdlet gives elevated permissions (for example, Power Platform Admin) to the app registration. Your organization's security policies may not allow for these types of permissions. Ensure that these permissions are allowed before continuing. In the case that these elevated permissions are not allowed certain capabilities won't work in the AA4PP pipelines.
 ```powershell
-Install-Module -Name Microsoft.PowerApps.Administration.PowerShell
+Install-Module -Name Microsoft.PowerApps.Administration.PowerShell -AllowClobber
 Install-Module -Name Microsoft.PowerApps.PowerShell -AllowClobber
 New-PowerAppManagementApp -ApplicationId [the Application (client) ID you copied when creating your app registration]
 ```


### PR DESCRIPTION
Added `-AllowClobber` to `Install-Module -Name Microsoft.PowerApps.Administration.PowerShell` command.

Fixes issue where `New-PowerAppManagementApp` cmdlet isn't available after performing existing steps to install cmdlet that did not work on my Windows 11 VM.

https://learn.microsoft.com/en-us/powershell/module/microsoft.powerapps.administration.powershell/new-powerappmanagementapp?view=pa-ps-latest