### PR TITLE
Remove incorrect deduction of an orphan app

### DIFF
--- a/power-platform/admin/powerapps-analytics-reports.md
+++ b/power-platform/admin/powerapps-analytics-reports.md
@@ -90,7 +90,7 @@ The Power Apps Maker Activity report provide insights into tenant and environmen
 
 ## Power Apps - Inventory report
 
-The Power Apps Inventory report offers a complete catalog of apps distributed across the tenant. This view includes the **Last opened** filter that allows admins to identify stale and orphaned apps. The report answers questions such as:
+The Power Apps Inventory report offers a complete catalog of apps distributed across the tenant. This view includes the **Last opened** filter that allows admins to identify stale apps. The report answers questions such as:
 
 - What is the total number of model-driven and canvas apps across the tenant or environments? 
 - Which apps depend on specific connectors?


### PR DESCRIPTION
Line 93 incorrectly states that an app is orphaned if it doesn't have a "Last opened" date value. This is not the case. An app may have an owner and not be orphaned, even if date value for last opened isn't present. I don't believe there's any report in PPAC that reliably displays orphaned canvas apps as the original creator owner is always displayed in tenant level analytics as well as when looking at Power Apps behind an environment in PPAC, even if the creator owner is no longer in AAD. The only reliable ways to distinguish orphaned apps are with the CoE Starter Kit's Set App Permissions and Power Platfrom Admin View apps.

The concept of an orphaned app also doesn't apply to model-driven apps as access to them is defined by security roles. In that sense, this Learn page is also misleading when it talks about orpahned apps.

Power Apps analytics. Based on Learn, theses apps are orphaned as they don't have a "Last opened" value:
![image](https://user-images.githubusercontent.com/64043240/232726951-80e88c69-5a1b-4968-bd10-6d196e1f086b.png)

One of the apps in CoE's Power Platform Admin View:
![image](https://user-images.githubusercontent.com/64043240/232727558-2eaef5aa-70ae-4dc7-acc7-835390f5dacb.png)


The rest of the apps are CoE canvas apps owned by a service account. They are not orphaned. Deducing they are orpahed based on this Learn article would be an incorrect deduction.