### PR TITLE
Note about adding multitenant apps as application users.

### DIFF
--- a/power-platform/admin/manage-application-users.md
+++ b/power-platform/admin/manage-application-users.md
@@ -59,6 +59,10 @@ In an environment, you can only have one application user for each Azure AD&ndas
 
    > [!NOTE]
    > In addition to entering the Application Name or Application ID, you can also enter an Azure Managed Identity Application ID. For Managed Identity, do not enter the Managed Identity Application Name, use the Managed Identity Application ID instead.
+   > 
+   > Enterprise Applications does not show in the list of applications, only Azre Active Directory App registrations will show. Search for the multitenant application by name or ID, to assign it to the applicatino user.  
+
+   
 
 7. The selected Azure AD app is displayed under **App**. You can select **Edit** (![Edit.](media/edit-button.png)) to choose another Azure AD application. Under **Business Unit**, select a business unit from the dropdown list.  
 

--- a/power-platform/admin/manage-application-users.md
+++ b/power-platform/admin/manage-application-users.md
@@ -60,7 +60,7 @@ In an environment, you can only have one application user for each Azure AD&ndas
    > [!NOTE]
    > In addition to entering the Application Name or Application ID, you can also enter an Azure Managed Identity Application ID. For Managed Identity, do not enter the Managed Identity Application Name, use the Managed Identity Application ID instead.
    > 
-   > Enterprise applications don't show in the list of applications, only Azre AD app registrations show in the list. Search for the multitenant application by name or ID to assign it to the applicatino user.  
+   > Enterprise applications don't show in the list of applications, only Azure AD app registrations show in the list. Search for the multitenant application by name or ID to assign it to the application user.  
 
 7. The selected Azure AD app is displayed under **App**. You can select **Edit** (![Edit.](media/edit-button.png)) to choose another Azure AD application. Under **Business Unit**, select a business unit from the dropdown list.  
 

--- a/power-platform/admin/manage-application-users.md
+++ b/power-platform/admin/manage-application-users.md
@@ -60,9 +60,7 @@ In an environment, you can only have one application user for each Azure AD&ndas
    > [!NOTE]
    > In addition to entering the Application Name or Application ID, you can also enter an Azure Managed Identity Application ID. For Managed Identity, do not enter the Managed Identity Application Name, use the Managed Identity Application ID instead.
    > 
-   > Enterprise Applications does not show in the list of applications, only Azre Active Directory App registrations will show. Search for the multitenant application by name or ID, to assign it to the applicatino user.  
-
-   
+   > Enterprise applications don't show in the list of applications, only Azre AD app registrations show in the list. Search for the multitenant application by name or ID to assign it to the applicatino user.  
 
 7. The selected Azure AD app is displayed under **App**. You can select **Edit** (![Edit.](media/edit-button.png)) to choose another Azure AD application. Under **Business Unit**, select a business unit from the dropdown list.  
 


### PR DESCRIPTION
Note about adding multitenant apps as application users.

Like with managed identities, enterprise applications needs to be exility added, as they do not show in the drop down (only app registrations does).