### PR TITLE
Update function-split.md

### DIFF
--- a/power-platform/power-fx/reference/function-split.md
+++ b/power-platform/power-fx/reference/function-split.md
@@ -48,19 +48,19 @@ The examples show how **Split** can be used with the **[First](function-first-la
 
 | Formula | Description | Result |
 | --- | --- | --- |
-| `Split( "Apples, Oranges, Bananas", "," )` | Splits the different fruits apart, based on the comma separator. The split is performed based on only the comma and not the space after it, resulting in a space at the front of "&nbsp;Oranges" and "&nbsp;Bananas". | A single-column table with a `Value` column containing the following values: "Apples", "&nbsp;Oranges", "&nbsp;Bananas" |
-| `TrimEnds( Split( "Apples, Oranges, Bananas", "," ) )` | Same as the previous example, but in this case the space is removed by the [**TrimEnds** function](function-trim.md), operating on the single column table that is produced by **Split**. We could have also used the separator **",&nbsp;"** which includes the space after the comma, but that wouldn't have worked properly if there's no space or there are two spaces. | A single-column table with a `Value` column containing the following values: "Apples", "Oranges", "Bananas" |
-| `Split( "08/28/17", "/" )` | Splits the date apart, using a forward slash as the separator. | A single-column table with a `Value` column containing the following values: "08", "28", "17"|
+| `Split( "Apples, Oranges, Bananas", ',' )` | Splits the different fruits apart, based on the comma separator. The split is performed based on only the comma and not the space after it, resulting in a space at the front of "&nbsp;Oranges" and "&nbsp;Bananas". | A single-column table with a `Value` column containing the following values: "Apples", "&nbsp;Oranges", "&nbsp;Bananas" |
+| `TrimEnds( Split( "Apples, Oranges, Bananas", ',' ) )` | Same as the previous example, but in this case the space is removed by the [**TrimEnds** function](function-trim.md), operating on the single column table that is produced by **Split**. We could have also used the separator **",&nbsp;"** which includes the space after the comma, but that wouldn't have worked properly if there's no space or there are two spaces. | A single-column table with a `Value` column containing the following values: "Apples", "Oranges", "Bananas" |
+| `Split( "08/28/17", '/' )` | Splits the date apart, using a forward slash as the separator. | A single-column table with a `Value` column containing the following values: "08", "28", "17"|
 
 ### Different delimiters
 
 | Formula | Description | Result |
 | --- | --- | --- |
-| `Split( "Hello, World", "," )` | Splits the words apart, using a comma as the separator. The second result starts with a space since it is the character immediately following the comma. | A single-column table with a `Value` column containing the following values: "Hello", "&nbsp; World" |
-| `Split( "Hello, World", "o" )` | Splits the string apart, using the character "o" as the separator. | A single-column table with a `Value` column containing the following values: "Hell", ", W", "rld" |
-| `Split( "Hello, World", "l" )` | Splits the string apart, using the single character "l" as the separator. Since there were no characters between both the **l**'s in **Hello**, a _blank_ value was returned. | A single-column table with a `Value` column containing the following values: "He", Blank(), "o, Wor", "d" |
-| `Split( "Hello, World", "ll" )` | Splits the string apart, using the double character "ll" as the separator. | A single-column table with a `Value` column containing the following values: "He", "o, World" |
-| `Split( "Hello, World", "%" )` | Splits the string apart, using the percent sign as the separator. Since this separator doesn't appear in the string, the entire string is returned as one result. | A single-column table with a `Value` column containing the following value: "Hello, World" |
+| `Split( "Hello, World", ',' )` | Splits the words apart, using a comma as the separator. The second result starts with a space since it is the character immediately following the comma. | A single-column table with a `Value` column containing the following values: "Hello", "&nbsp; World" |
+| `Split( "Hello, World", 'o' )` | Splits the string apart, using the character "o" as the separator. | A single-column table with a `Value` column containing the following values: "Hell", ", W", "rld" |
+| `Split( "Hello, World", 'l' )` | Splits the string apart, using the single character "l" as the separator. Since there were no characters between both the **l**'s in **Hello**, a _blank_ value was returned. | A single-column table with a `Value` column containing the following values: "He", Blank(), "o, Wor", "d" |
+| `Split( "Hello, World", 'll' )` | Splits the string apart, using the double character "ll" as the separator. | A single-column table with a `Value` column containing the following values: "He", "o, World" |
+| `Split( "Hello, World", '%' )` | Splits the string apart, using the percent sign as the separator. Since this separator doesn't appear in the string, the entire string is returned as one result. | A single-column table with a `Value` column containing the following value: "Hello, World" |
 | `Split( "Hello, World", "" )` | Splits the string apart, using an empty string as the separator (zero characters). This will break the string on each character. | A single-column table with a `Value` column containing the following values: "H", "e", "l", "l", "o", ",", "&nbsp;", "W", "o", "r", "l", "d" |
 
 ### Substring extraction


### PR DESCRIPTION
When using the split function, the double quotes does not work and we need to use the single quotes in the power automate platform hence changed the examples which had double quotes and replaced them with the single quotes.