### PR TITLE
Update connector-endpoint-filtering.md

### DIFF
--- a/power-platform/admin/connector-endpoint-filtering.md
+++ b/power-platform/admin/connector-endpoint-filtering.md
@@ -28,7 +28,7 @@ Connector endpoint filtering allows admins to govern which specific endpoints ma
 - HTTP
 - HTTP with Microsoft Entra ID (AD)
 - HTTP Webhook
-- SQL Server
+- SQL Server (includes using SQL Server connector to access Azure Synapse datawarehouse)
 - Azure Blob Storage 
 - SMTP 
 

--- a/power-platform/admin/connector-endpoint-filtering.md
+++ b/power-platform/admin/connector-endpoint-filtering.md
@@ -28,7 +28,7 @@ Connector endpoint filtering allows admins to govern which specific endpoints ma
 - HTTP
 - HTTP with Microsoft Entra ID (AD)
 - HTTP Webhook
-- SQL Server (includes using SQL Server connector to access Azure Synapse datawarehouse)
+- SQL Server (includes using SQL Server Connector to access Azure Synapse data warehouse)
 - Azure Blob Storage 
 - SMTP 
 


### PR DESCRIPTION
Users of Power Automate/ Power Apps have been confused because they could not find documentation that confirms that these rules also apply to SQL server connectors accessing Azure Synapse datawarehouses.  Customers have been confused and not aware that Azure Synapse is a SQL database that happens to be a datawarehouse.