### PR TITLE
Clarified types of mailboxes which support sync - `Alias` vs `Contact`

### DIFF
--- a/power-platform/admin/server-side-synchronization.md
+++ b/power-platform/admin/server-side-synchronization.md
@@ -27,7 +27,7 @@ Using server-side synchronization makes messaging data available to a web browse
 > A user can only map to a single [!INCLUDE[pn_Exchange](../includes/pn-exchange.md)] or POP3 mailbox. Similarly, an [!INCLUDE[pn_Exchange](../includes/pn-exchange.md)] or POP3 mailbox can only be mapped to a single user. When customer engagement apps detect that an [!INCLUDE[pn_Exchange](../includes/pn-exchange.md)] or POP3 mailbox has already been mapped to a user, a dialog box is displayed to present a choice to the user whether to map the user to the [!INCLUDE[pn_Exchange](../includes/pn-exchange.md)] mailbox. When the user selects **Yes**, it breaks the previous user-to-[!INCLUDE[pn_Exchange](../includes/pn-exchange.md)]-mailbox mapping and, subsequently, the synchronization that would occur between the user and the [!INCLUDE[pn_Exchange](../includes/pn-exchange.md)] mailbox.
 
 > [!NOTE]
-> Only mailboxes can be configured for synchronization. Using aliases or distribution lists is not supported because the synchronization process is asynchronous and those types of resources don't store the emails.
+> Only mailboxes can be configured for synchronization. Using contacts or distribution lists is not supported because the synchronization process is asynchronous and those types of resources don't store the emails.
   
 ## Server-side synchronization frequency
 Server-side synchronization runs on a schedule for each mailbox and has different synchronization delays based on the workload processed. Available workloads are incoming emails, outgoing emails, and appointments, contacts, and tasks synchronization.


### PR DESCRIPTION
The documentation states that "Aliases" are not supported for synchronisation. However, this term is confusing, as there are [SMTP Aliases](https://learn.microsoft.com/en-us/microsoft-365/admin/email/add-another-email-alias-for-a-user?view=o365-worldwide) which are linked to an existing mailbox, and mailboxes which have SMTP aliases are supported as far as I know.

There are also [Exchange Online "Contacts"](https://learn.microsoft.com/en-us/exchange/recipients-in-exchange-online/manage-mail-contacts) which do not store mail, and are used for users outside the organisation. I believe this is the term this article is referring to.