### PR TITLE
Add "# SSSAdminProd" application user to the docs

### DIFF
--- a/power-platform/admin/system-application-users.md
+++ b/power-platform/admin/system-application-users.md
@@ -3,7 +3,7 @@ title: "Special system users and application users"
 description: "Learn about the special system and application users created when the system is provisioned, including assigned security role, user name, and purpose." 
 ms.component: pa-admin
 ms.topic: conceptual
-ms.date: 04/19/2024
+ms.date: 08/13/2024
 author: paulliew
 ms.subservice: admin
 ms.author: paulliew
@@ -12,6 +12,7 @@ ms.custom: "admin-security"
 search.audienceType: 
   - admin
 ms.contributors:
+- gattimassimo
 - saponcer
 ---
 

--- a/power-platform/admin/system-application-users.md
+++ b/power-platform/admin/system-application-users.md
@@ -74,6 +74,7 @@ Most of these users are hidden from user views but they can be found by using th
 | # DataSyncFramework-\<REGION\> | DataSyncFramework-\<REGION\>@onmicrosoft.com | To read data for Azure Data Lake sync | Data Sync Framework  |
 | # Sharepoint Syntex | SharepointSyntex@onmicrosoft.com | To allow Sharepoint to use AI Builder document processing models | Basic User  |
 | # InsightsAppsPlatform | InsightsAppsPlatform@onmicrosoft.com | For insights generation and ingestion of data into Dataverse | Insights Apps Platform Role  |
+| # SSSAdminProd | SSSAdminProd@onmicrosoft.com | To allow Server Side Sync to integrate with Dataverse | System admin    |
 | Apollo | capaeinfra@microsoft.com | For performing organization lifecycle operations for Dataverse | Service Writer Role |
 
 ## The purpose of the system account?


### PR DESCRIPTION
Server Side Sync is now using a new application user to interact with Dataverse. This needs to be documented.