### PR TITLE
Update default-environment-routing.md

### DIFF
--- a/power-platform/admin/default-environment-routing.md
+++ b/power-platform/admin/default-environment-routing.md
@@ -59,9 +59,6 @@ The **Environment routing** setting is disabled by default and must be enabled u
 1. (Optional) Select an environment group, to which the newly created developer environments are automatically assigned. This environment group inherits all the defined environment group rules. For more information, see [Environments groups](environment-groups.md).
 1. (Optional) Admins can select a security group to limit routing only to the member makers of the configured security group. For more information, see [Configure security groups](../enterprise-templates/finance/sap-procurement/administer/configure-security-groups.md).
 
-    > [!Note]
-    > Currently security group filtering only works for security groups that have one hundred members or less. 
-
     :::image type="content" source="media/default-environment-routing/environment-routing.png" alt-text="Screenshot that shows where various Environment routing options in Tenant settings are located." lightbox="media/default-environment-routing/environment-routing.png":::
 
 


### PR DESCRIPTION
Removing note for "Currently security group filtering only works for security groups that have one hundred members or less" as this restriction no longer applies.