### PR TITLE
Remove parameter "DisableAdminMode" from Power Platform Copy Environment devops-build-tool-tasks.md

### DIFF
--- a/power-platform/alm/devops-build-tool-tasks.md
+++ b/power-platform/alm/devops-build-tool-tasks.md
@@ -719,7 +719,6 @@ steps:
 | `CopyType`<br/>Copy type | The type of copy to perform: FullCopy or MinimalCopy |
 | `OverrideFriendlyName`<br/>Override friendly name | Change the target environment's friendly name to another name (true\|false). |
 | `FriendlyName`<br/>Friendly name | The friendly name of the target environment. |
-| `DisableAdminMode`<br/>Disable admin mode | Whether to disable administration mode (true\|false). |
 
 ### Power Platform Restore Environment
 

--- a/power-platform/alm/devops-build-tool-tasks.md
+++ b/power-platform/alm/devops-build-tool-tasks.md
@@ -4,7 +4,7 @@ description: "Learn about what build tool tasks are available plus some examples
 author: marcelbf
 ms.author: marcelbf
 ms.subservice: alm
-ms.date: 03/29/2024
+ms.date: 12/03/2024
 ms.reviewer: pehecke
 ms.topic: article
 search.audienceType: 

--- a/power-platform/alm/devops-build-tool-tasks.md
+++ b/power-platform/alm/devops-build-tool-tasks.md
@@ -706,6 +706,7 @@ steps:
     CopyType: MinimalCopy
     OverrideFriendlyName: true
     FriendlyName: 'Contoso Test'
+    SkipAuditData: true
 ```
 
 #### Parameters (Copy-env)
@@ -719,6 +720,7 @@ steps:
 | `CopyType`<br/>Copy type | The type of copy to perform: FullCopy or MinimalCopy |
 | `OverrideFriendlyName`<br/>Override friendly name | Change the target environment's friendly name to another name (true\|false). |
 | `FriendlyName`<br/>Friendly name | The friendly name of the target environment. |
+| `SkipAuditData`<br/>SkipAuditData | Whether to skip audit data during copy operation. (true|false). |
 
 ### Power Platform Restore Environment
 

--- a/power-platform/alm/devops-build-tool-tasks.md
+++ b/power-platform/alm/devops-build-tool-tasks.md
@@ -706,7 +706,6 @@ steps:
     CopyType: MinimalCopy
     OverrideFriendlyName: true
     FriendlyName: 'Contoso Test'
-    DisableAdminMode: false
 ```
 
 #### Parameters (Copy-env)


### PR DESCRIPTION
Parameter removed in pull request https://github.com/microsoft/powerplatform-build-tools/pull/1000, but is not removed from Docs.