### PR TITLE
Update tutorial-perform-transactionless-copy.md

### DIFF
--- a/power-platform/admin/unified-experience/tutorial-perform-transactionless-copy.md
+++ b/power-platform/admin/unified-experience/tutorial-perform-transactionless-copy.md
@@ -70,12 +70,12 @@ Write-Host "Creating a session against the Power Platform API"
 
 Add-PowerAppsAccount -Endpoint prod -TenantID $TenantId -ApplicationId $SPNId -ClientSecret $ClientSecret
 
-    $copyToRequest = \[pscustomobject\]@{
+    $copyToRequest = [pscustomobject]@{
         SourceEnvironmentId = $SourceEnvironmentID
         TargetEnvironmentName = "Copied from source"
         CopyType = "FullCopy"
-        SkipAuditData: true
-        ExecuteAdvancedCopyForFinanceAndOperations: true
+        SkipAuditData = $true
+        ExecuteAdvancedCopyForFinanceAndOperations = $true
     }
 
 Copy-PowerAppEnvironment -EnvironmentName $TargetEnvironmentID -CopyToRequestDefinition $copyToRequest


### PR DESCRIPTION
fixed the syntax of the script because the former version did not work within PowerShell5