### PR TITLE
Remove early reslease cycles dependency as public preview annunced

### DIFF
--- a/power-platform/alm/git-integration/connecting-to-git.md
+++ b/power-platform/alm/git-integration/connecting-to-git.md
@@ -22,7 +22,6 @@ Git integration in Dataverse is initiated from Power Platform in the **Solutions
 >
 > - This is a preview feature.
 > - [!INCLUDE [cc-preview-features-definition](../../includes/cc-preview-features-definition.md)]
-> - This feature is currently only available to environments that have been created for early release cycles. Go to [Early release cycle environments](/power-platform/admin/early-release#create-early-release-cycle-environments).
 
 ## Prerequisites for Git integration with Dataverse
 


### PR DESCRIPTION
After public preview of this feature announced in https://www.microsoft.com/en-us/power-platform/blog/power-apps/introducing-git-integration-in-power-platform-preview/, this early access no longer needed. In actual, I can see this feature in Standard environments now.