### PR TITLE
Update Model Version Text

### DIFF
--- a/power-platform/developer/cli/reference/includes/pages-download-intro.md
+++ b/power-platform/developer/cli/reference/includes/pages-download-intro.md
@@ -1,5 +1,5 @@
 ### Example
 
 ```powershell
-pac pages download --path "C:\portals" --webSiteId f88b70cc-580b-4f1a-87c3-41debefeb902
+pac pages download --path "C:\portals" --webSiteId f88b70cc-580b-4f1a-87c3-41debefeb902 --modelVersion 2
 ```

--- a/power-platform/developer/cli/reference/includes/pages-upload-intro.md
+++ b/power-platform/developer/cli/reference/includes/pages-upload-intro.md
@@ -1,5 +1,5 @@
 ### Example
 
 ```powershell
-pac pages upload --path "C:\portals\starter-portal"
+pac pages upload --path "C:\portals\starter-portal" --modelVersion 2
 ``` 

--- a/power-platform/developer/cli/reference/pages.md
+++ b/power-platform/developer/cli/reference/pages.md
@@ -82,7 +82,7 @@ Download only the entities specified for this argument using comma separated ent
 
 #### `--modelVersion` `-mv`
 
-Power Pages website data model version to download. When not specified, 'Standard' will be used. [1: Standard, 2: Enhanced]
+Power Pages website data model version to download. When not specified, 'Standard' will be used. [Enhanced or Standard]
 
 #### `--overwrite` `-o`
 
@@ -197,7 +197,7 @@ This parameter requires no value. It's a switch.
 
 #### `--modelVersion` `-mv`
 
-Power Pages website data model version to upload. [1: Standard, 2: Enhanced]
+Power Pages website data model version to upload.
 
 [!INCLUDE [pages-upload-remarks](includes/pages-upload-remarks.md)]
 


### PR DESCRIPTION
The pac pages upload and download commands have a --modelVersion switch.  The existing documentation said to use Enhanced or Standard as the command line values but those are inaccurate.  The values are 1 for Standard and 2 for Enhanced.  This update clarifies that.