### PR TITLE
Fix Header Name

### DIFF
--- a/power-platform/admin/telemetry-events-dataverse.md
+++ b/power-platform/admin/telemetry-events-dataverse.md
@@ -220,7 +220,7 @@ Any outbound call made by the plug-in will automatically be logged as a dependen
 
 ### Can I view telemetry for a specific request? 
 
-Dataverse returns x-ms-service-requestId in the header response to all requests. Using this requestId, you can query for all telemetry. 
+Dataverse returns `x-ms-service-request-id` in the header response to all requests. Using this request ID, you can query for all telemetry. 
 
 ```kusto
 union *


### PR DESCRIPTION
# Issue

[Current doc on Dataverse API telemetry](https://learn.microsoft.com/en-us/power-platform/admin/telemetry-events-dataverse) has incorrect header name. 

`x-ms-service-requestId` was no used anywhere in code. The actual header names used in code is `x-ms-service-request-id`. 