### PR TITLE
Update vnet-support-overview.md

### DIFF
--- a/power-platform/admin/vnet-support-overview.md
+++ b/power-platform/admin/vnet-support-overview.md
@@ -53,7 +53,7 @@ Power Platform enables Virtual Network support for both Dataverse plug-ins and [
 ### Limitations
 
 - [Dataverse low-code plug-ins](/power-apps/maker/data-platform/low-code-plug-ins) that use connectors aren't supported until those connector types are updated to use subnet delegation.
-- You use copy, backup, and restore [environment lifecycle operations](/dynamics365/fin-ops-core/dev-itpro/power-platform/environment-lifecycle-core-concepts#terminology-differences-between-lifecycle-services-and-power-platform-admin-center) on virtual network-supported Power Platform environments. The restore operation can be performed within the same virtual network, as well as across different environments, provided they're connected to the same virtual network. Additionally, the restore operation is permissible from environments that don't support virtual networks to those that do.
+- You use copy, backup, and restore [environment lifecycle operations](/dynamics365/fin-ops-core/dev-itpro/power-platform/environment-lifecycle-core-concepts#terminology-differences-between-lifecycle-services-and-power-platform-admin-center) on virtual network-supported Power Platform environments. The restore and copy operation can be performed within the same enterprise policy, as well as across different environments, provided the source and target environment are in the same enterprise policy (deletegated subnet). Additionally, the restore operation is permissible from environments that don't support virtual networks to those that do.
 
 ## Supported regions
 


### PR DESCRIPTION
We are currently doing this item of work (copying an environment form a source to a target), the source and target environments must be in the same enterprise policy/delegated subnet, not just virtual network. The previous wording was incorrect.