### PR TITLE
Fixed a typo in operators.md

### DIFF
--- a/power-platform/power-fx/reference/operators.md
+++ b/power-platform/power-fx/reference/operators.md
@@ -278,7 +278,7 @@ Some data sources such as SharePoint and Microsoft Dataverse have two different 
 
 - **Display name** - A name that is user-friendly and intended to be seen by end users. This name may not be unique, may change over time, may contain spaces and any Unicode character, and may be localized into different languages. Corresponding to the example above, the display name may be **Custom Field** with space in between the words.
 
-Since display names are easier to understand, Canvas apps will suggest them as choices and not suggest logical names. Although logical names aren't suggested, they can still be used if typed indirectly.
+Since display names are easier to understand, Canvas apps will suggest them as choices and not suggest logical names. Although logical names aren't suggested, they can still be used if typed in directly.
 
 For example, imagine you've added a **Custom Field** to a table in Dataverse. A logical name will be assigned for you by the system, which you can modify only when creating the field. The result would look similar to:
 


### PR DESCRIPTION
This text should say "typed in" because it refers to the programmer typing a variable name.