### PR TITLE
Remove map and location description

### DIFF
--- a/power-platform/admin/analytics-powerapps.md
+++ b/power-platform/admin/analytics-powerapps.md
@@ -45,11 +45,6 @@ There are six reports available for Power Apps admins. The last viewed environme
 > [!div class="mx-imgBorder"] 
 > ![Power Apps analytics usage report.](media/powerapps-analytics-usage.png "Power Apps analytics usage report")
 
-**Location** report provides a map-based view of usage. It gives an insight into regional adoption and usage trends.  
-
-> [!div class="mx-imgBorder"] 
-> ![Power Apps analytics location report.](media/powerapps-analytics-location.png "Power Apps analytics location report")
-
 **Toast Errors** report provides insights into the toast error trends, types, and counts per app to help drive improvements in app quality. The toast errors are errors displayed to the end users of the app. 
 
 > [!div class="mx-imgBorder"] 


### PR DESCRIPTION
Removing the Location report and map image from public doc of PPAC Analytics Report as it is no longer relevant and supported