### PR TITLE
Add AzureSignalR to list of required Service Tags in online requirements

### DIFF
--- a/power-platform/admin/online-requirements.md
+++ b/power-platform/admin/online-requirements.md
@@ -86,7 +86,7 @@ Add the IP address values for the following service tags.
 |  Service tag | Purpose  |
 |---|---|
 | `AzureCloud` | Needed for all Power Platform and Dynamics 365 services. |
-| 'AzureSignalR' | Needed for Power Apps real-time collaboration features. |
+| `AzureSignalR` | Needed for Power Apps real-time collaboration features. |
 | `MicrosoftAzureFluidRelay` | Needed for real-time collaboration features. |
 | `OneDsCollector` | Needed for gathering telemetry. |
 | `PowerPlatformPlex` | Needed to access external web services from Dataverse sandbox plug-ins. |

--- a/power-platform/admin/online-requirements.md
+++ b/power-platform/admin/online-requirements.md
@@ -86,6 +86,7 @@ Add the IP address values for the following service tags.
 |  Service tag | Purpose  |
 |---|---|
 | `AzureCloud` | Needed for all Power Platform and Dynamics 365 services. |
+| 'AzureSignalR' | Needed for Power Apps real-time collaboration features. |
 | `MicrosoftAzureFluidRelay` | Needed for real-time collaboration features. |
 | `OneDsCollector` | Needed for gathering telemetry. |
 | `PowerPlatformPlex` | Needed to access external web services from Dataverse sandbox plug-ins. |


### PR DESCRIPTION
Add AzureSignalR to list of required Service Tags in online requirements. This service is being used by collaboration features in Power Apps maker experiences.