### PR TITLE
Update outdated component names in devops-build-tools.md

### DIFF
--- a/power-platform/alm/devops-build-tools.md
+++ b/power-platform/alm/devops-build-tools.md
@@ -21,8 +21,8 @@ to apps built on Microsoft Power Platform. These tasks include:
   - Customer engagement apps: Dynamics 365 Sales, Customer Service, Field Service, Marketing, and Project Service Automation
   - Canvas apps
   - Model-driven apps
-  - UI flows
-  - Virtual agents
+  - Desktop flows
+  - Copilot Studio agents
   - AI Builder models
   - Connectors between development environments and source control
 - Generating build artifacts


### PR DESCRIPTION
**Summary**
Updated outdated component names to match current Power Platform terminology:
- "UI flows" --> “Desktop flows" (Power Automate Desktop)
- "Virtual agents" --> “Copilot Studio agents”

**Type**
Documentation terminology update (no functional changes)