### PR TITLE
docs: document YAML source control format for SolutionPackager and pac CLI

### DIFF
--- a/power-platform/alm/TOC.yml
+++ b/power-platform/alm/TOC.yml
@@ -185,6 +185,8 @@
               href: solution-packager-tool.md
             - name: Source control with solution files
               href: use-source-control-solution-files.md
+            - name: Solution YAML source control format
+              href: solution-source-control-yaml-format.md
         - name: Verify quality of solutions and packages
           items:
             - name: Use the Power Apps checker web API

--- a/power-platform/alm/git-integration/faqs.md
+++ b/power-platform/alm/git-integration/faqs.md
@@ -84,6 +84,16 @@ Before this feature became available, it was common to store managed and unmanag
 
 The feature uses YAML to represent solution content because it's easier to read, understand, and facilitates easier merges.
 
+## What folder structure does the YAML source control format use?
+
+When solutions are committed using Dataverse Git integration, or extracted using `pac solution clone`, they're stored in a specific folder layout under the repository root:
+
+- `solutions/<SolutionUniqueName>/` — contains `solution.yml` and supporting manifest files (`solutioncomponents.yml`, `rootcomponents.yml`, `missingdependencies.yml`)
+- `publishers/<PublisherUniqueName>/` — contains `publisher.yml`
+- Component folders (`entities/`, `workflows/`, `canvasapps/`, and so on) at the repository root
+
+This structure is required when you manually pack the folder back into a `.zip` file using SolutionPackager or `pac solution pack`. Placing the YAML files at the repository root instead of under `solutions/<name>/` causes a misleading error about a missing `Customizations.xml`. For a complete reference, see [Solution YAML source control format](../solution-source-control-yaml-format.md).
+
 ## How can I build and deploy a solution from source code?
 
 Currently, deployment requires synchronizing the Git release branch with a development environment and exporting the managed artifact from the environment. <!-- Update this FAQ when expanded feature becomes available.-->
@@ -124,7 +134,7 @@ Currently, some low-usage legacy object types are unsupported. You receive an er
 
 ## How can I upgrade existing solutions?
 
-You can connect existing solutions in an environment to Git and commit them. If the solution is only in Git, first use developer tools to pack and import the unmanaged solution into a new development environment. We recommend a new source code location to avoid disruptive changes between old and new file formats.
+You can connect existing solutions in an environment to Git and commit them. If the solution is only in Git, first use developer tools to pack and import the unmanaged solution into a new development environment. We recommend a new source code location to avoid disruptive changes between old and new file formats. For more information about packing a YAML source-controlled solution, see [SolutionPackager tool](../solution-packager-tool.md#source-control-file-formats).
 
 ## Can I use Git integration to audit metadata changes? Even for citizen developers?
 

--- a/power-platform/alm/solution-packager-tool.md
+++ b/power-platform/alm/solution-packager-tool.md
@@ -53,8 +53,74 @@ Find the SolutionPackager.exe executable in the \<extracted-folder-name\>/conten
 |@ \<file path>|Optional. A path and name to a file that contains command-line arguments for the tool.|  
 |/sourceLoc: \<string>|Optional. This argument generates a template resource file, and is valid only on extract.<br /><br /> Possible values are `auto` or an LCID/ISO code for the language you want to export. When this argument is used, the string resources from the given locale are extracted as a neutral .resx file. If `auto` or just the long or short form of the switch is specified, the base locale or the solution is used. You can use the short form of the command: /src.|  
 |/localize|Optional. Extract or merge all string resources into .resx files. You can use the short form of the command: /loc. The localize option supports shared components for .resx files. More information: [Using RESX web resources](/power-apps/developer/model-driven-apps/resx-web-resources)|  
-  
+|/SolutionName: \<name>|Optional. The unique name of the solution to pack or extract when the source folder contains multiple solutions under `solutions/*/solution.yml`. Required when more than one solution is detected. Only applies to the YAML source control format. You can use the short form of the command: /sn.|
+|/remapPluginTypeNames|Optional. When specified, plug-in fully qualified type names are remapped based on the assemblies included in the solution. Enabled by default in the YAML source control format. You can use the short form of the command: /fp.|
+
 <a name="use_command"></a>
+
+## Source control file formats
+
+SolutionPackager supports two folder layouts when extracting and packing solutions.
+
+### XML format (legacy)
+
+The original format. Solution metadata is stored in `Other\Solution.xml` and `Other\Customizations.xml`, and all component files are extracted into a flat folder hierarchy alongside those files. This is the default format when extracting a `.zip` file without additional configuration.
+
+### YAML source control format
+
+Introduced alongside [Dataverse Git integration](git-integration/overview.md), this format stores solution metadata as YAML files distributed across a structured folder hierarchy. It's the format written when you commit solutions using native Git integration in Power Apps.
+
+**Advantages over XML format:**
+- Produces cleaner, more readable per-component diffs in source control
+- Supports multiple solutions in a single repository folder
+- Canvas app `.msapp` files and modern flows are only supported in this format
+- Plug-in type name remapping is enabled by default
+
+**Required folder structure:**
+
+```
+<rootFolder>/
+├── solutions/
+│   └── <SolutionUniqueName>/
+│       ├── solution.yml              (solution metadata)
+│       ├── solutioncomponents.yml    (paths to all component files)
+│       ├── rootcomponents.yml        (root-level components)
+│       └── missingdependencies.yml   (dependency info)
+├── publishers/
+│   └── <PublisherUniqueName>/
+│       └── publisher.yml             (publisher definition)
+├── entities/                         (entity components, if present)
+├── workflows/                        (classic workflows, if present)
+├── modernflows/                      (Power Automate cloud flows, if present)
+├── canvasapps/                       (canvas app .msapp files, if present)
+└── [other component folders]/
+```
+
+> [!IMPORTANT]
+> The YAML format is auto-detected by the presence of a `solutions/` subfolder containing `*solution.yml` files.
+> If your YAML manifest files (`solution.yml`, `solutioncomponents.yml`, and so on) are placed at the **root** of the folder rather than under `solutions/<SolutionUniqueName>/`, the tool doesn't detect the YAML format. It falls back to the XML path and reports a misleading error about a missing `Customizations.xml`. See [Troubleshooting](#troubleshooting) for how to fix this.
+
+**Format auto-detection rules:**
+
+| Condition | Format used |
+|---|---|
+| `solutions/*/solution.yml` found — exactly one solution | YAML format; solution name inferred from folder |
+| `solutions/*/solution.yml` found — multiple solutions | YAML format; `/SolutionName` argument required |
+| No `solutions/` subdirectory present | XML format (legacy) |
+
+**Packing a YAML format folder:**
+
+```
+SolutionPackager.exe /action:Pack /zipfile:MySolution.zip /folder:C:\repos\myrepo
+```
+
+**Packing from a multi-solution folder:**
+
+```
+SolutionPackager.exe /action:Pack /zipfile:SolutionA.zip /folder:C:\repos\myrepo /SolutionName:SolutionA
+```
+
+
 
 ## Use the /map command argument  
 
@@ -270,8 +336,39 @@ If you use Visual Studio to edit resource files created by the solution packager
    ```  
   
    This allows the solution packager to read and import the resource file. This problem has only been observed when using the Visual Studio Resource editor.  
-  
-### See also  
+
+### Error: "Cannot find required file …\Other\Customizations.xml" with a YAML folder
+
+This error appears when you run SolutionPackager (or `pac solution pack`) against a folder that contains YAML files such as `solution.yml`, but those files are placed at the **root of the folder** rather than inside the required `solutions/<SolutionUniqueName>/` subfolder.
+
+**Cause:** The tool detects the YAML source control format by looking for a `solutions/` subfolder containing `*solution.yml` files. When that directory is absent, the tool silently falls back to the XML (legacy) format and expects `Other\Customizations.xml`. The resulting error message refers to an XML file and doesn't mention YAML — this is misleading.
+
+**Fix:** Reorganize the folder so that the YAML manifest files are under the correct paths:
+
+```
+<rootFolder>/
+  solutions/<YourSolutionUniqueName>/   ← move solution.yml here
+    solution.yml
+    solutioncomponents.yml
+    rootcomponents.yml
+    missingdependencies.yml
+  publishers/<YourPublisherUniqueName>/
+    publisher.yml
+```
+
+If you obtained the folder from a Git integration commit or `pac solution clone`, the folder structure should already be correct. A folder that only contains the top-level YAML files without the `solutions/` subdirectory represents an **incomplete extract** and can't be packed directly.
+
+### Warning: component declared in rootcomponents.yml has no source files
+
+This warning appears when a component — such as a canvas app — is listed in `rootcomponents.yml` but no corresponding source files exist in the expected component folder (for example, `canvasapps/<schema-name>/`).
+
+**Effect:** The tool still succeeds (exit code 0) and produces a valid `.zip` file, but the declared component is **omitted** from the packaged solution.
+
+**Cause:** The folder was produced by a partial extract, or the component's source files weren't included in the repository (for example, only the solution manifest files were committed, not the canvas app itself).
+
+**Fix:** Ensure all components declared in `rootcomponents.yml` have corresponding source files present in the folder. For canvas apps, the `.msapp` file must exist under `canvasapps/<schema-name>/`. If any files are missing, re-export the full solution from Dataverse and unpack it again, or use `pac solution clone` to obtain a complete extract.
+
+### See also
 
  [Use Source Control with Solution Files](use-source-control-solution-files.md)<br/>
  [Solution concepts](solution-concepts-alm.md)

--- a/power-platform/alm/solution-source-control-yaml-format.md
+++ b/power-platform/alm/solution-source-control-yaml-format.md
@@ -21,6 +21,9 @@ This article is a reference for the YAML-based source control format used when y
 
 The YAML format differs from the classic XML layout. Understanding the structure is important when you want to manually pack a YAML folder back into a `.zip` file that Dataverse can import.
 
+> [!IMPORTANT]
+> YAML source control format support in the `pac` CLI requires **Microsoft.PowerApps.CLI version 2.4.1 or later**. Download the latest version from [NuGet](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/2.4.1) or update via `pac install latest`. SolutionPackager.exe, which ships with the NuGet package, supports the YAML format from the same version.
+
 ## Folder structure overview
 
 A YAML-format repository root contains the following top-level directories:

--- a/power-platform/alm/solution-source-control-yaml-format.md
+++ b/power-platform/alm/solution-source-control-yaml-format.md
@@ -1,0 +1,237 @@
+---
+title: "Solution YAML source control format reference"
+description: "Reference for the YAML-based source control folder format used by Dataverse Git integration and SolutionPackager. Covers folder structure, manifest files, supported component types, and multi-solution repositories."
+ms.custom: ""
+ms.date: 04/07/2026
+ms.reviewer: "pehecke"
+ms.topic: reference
+author: "shmcarth"
+ms.subservice: alm
+ms.author: "jdaly"
+search.audienceType:
+  - developer
+---
+# Solution YAML source control format reference
+
+This article is a reference for the YAML-based source control format used when you:
+
+- Commit solutions using native [Dataverse Git integration](git-integration/overview.md) in Power Apps.
+- Extract solutions using `pac solution clone` or `pac solution sync`.
+- Manually run SolutionPackager against a folder that contains YAML manifest files.
+
+The YAML format differs from the classic XML layout. Understanding the structure is important when you want to manually pack a YAML folder back into a `.zip` file that Dataverse can import.
+
+## Folder structure overview
+
+A YAML-format repository root contains the following top-level directories:
+
+```
+<repositoryRoot>/
+├── solutions/
+│   └── <SolutionUniqueName>/       (one subfolder per solution)
+│       ├── solution.yml
+│       ├── solutioncomponents.yml
+│       ├── rootcomponents.yml
+│       └── missingdependencies.yml
+├── publishers/
+│   └── <PublisherUniqueName>/      (one subfolder per publisher)
+│       └── publisher.yml
+├── entities/                        (entity components, if any)
+│   └── <entity_schema_name>/
+│       ├── attributes/
+│       ├── formxml/
+│       ├── savedqueries/
+│       └── ...
+├── workflows/                       (classic workflow definitions, if any)
+├── modernflows/                     (Power Automate cloud flows, if any)
+├── canvasapps/                      (canvas app .msapp files, if any)
+│   └── <canvas_app_schema_name>/
+│       └── <name>.msapp
+├── environmentvariabledefinitions/  (environment variable definitions, if any)
+├── connectors/                      (custom connectors, if any)
+└── [other component folders]/
+```
+
+The `solutions/` and `publishers/` directories are **required**. All component folders at the root are optional and depend on what the solution contains.
+
+> [!IMPORTANT]
+> All YAML manifest files (`solution.yml`, `publisher.yml`, and so on) must be placed under their respective subdirectories (`solutions/<name>/`, `publishers/<name>/`). Placing them at the repository root prevents format detection and causes the SolutionPackager tool to fall back to the XML format — producing a misleading error about a missing `Customizations.xml`. More information: [SolutionPackager tool troubleshooting](solution-packager-tool.md#troubleshooting)
+
+## Format auto-detection
+
+SolutionPackager (and `pac solution pack`) auto-detect the format as follows:
+
+| Condition | Detected format | Behavior |
+|---|---|---|
+| `solutions/*/solution.yml` found — one solution | YAML | Solution name inferred from the subfolder name |
+| `solutions/*/solution.yml` found — multiple solutions | YAML | `/SolutionName` argument required to specify which solution to pack |
+| No `solutions/` subdirectory present | XML (legacy) | Expects `Other\Solution.xml` and `Other\Customizations.xml` |
+
+## Manifest files
+
+### solution.yml
+
+Located at `solutions/<SolutionUniqueName>/solution.yml`. Contains top-level solution metadata — the YAML equivalent of `solution.xml` in the XML format.
+
+Key fields include the solution's unique name, version, friendly name, description, and a reference to the publisher.
+
+### solutioncomponents.yml
+
+Located at `solutions/<SolutionUniqueName>/solutioncomponents.yml`. Lists relative paths to all component files included in this solution. SolutionPackager reads this file during pack to locate component sources.
+
+Example excerpt:
+
+```yaml
+- Path: entities/account
+- Path: entities/contact
+- Path: canvasapps/myapp_<guid>
+- Path: publishers/MyPublisher
+```
+
+### rootcomponents.yml
+
+Located at `solutions/<SolutionUniqueName>/rootcomponents.yml`. Lists the root-level components (typically tables and other top-level objects) that belong to this solution.
+
+> [!NOTE]
+> If a component is declared in `rootcomponents.yml` but its source files are absent from the folder, SolutionPackager emits a warning and omits that component from the packed `.zip`. The pack operation still completes successfully with exit code 0.
+
+### missingdependencies.yml
+
+Located at `solutions/<SolutionUniqueName>/missingdependencies.yml`. Records any solution dependencies that weren't present when the solution was last exported. Used for informational purposes and to validate completeness on import.
+
+### publisher.yml
+
+Located at `publishers/<PublisherUniqueName>/publisher.yml`. Contains the publisher definition — unique name, display name, customization prefix, and option value prefix.
+
+Minimal required structure:
+
+```yaml
+Publisher:
+  UniqueName: mypublisher
+  LocalizedNames:
+    LocalizedName:
+      '@description': My Publisher
+      '@languagecode': '1033'
+  Descriptions:
+  EMailAddress:
+    '@xsi:nil': 'true'
+    '@xmlns:xsi': http://www.w3.org/2001/XMLSchema-instance
+  SupportingWebsiteUrl:
+    '@xsi:nil': 'true'
+    '@xmlns:xsi': http://www.w3.org/2001/XMLSchema-instance
+  CustomizationPrefix: myp
+  CustomizationOptionValuePrefix: '12345'
+  Addresses:
+```
+
+## Component type support
+
+The following table lists how each component type is handled in the YAML format.
+
+| Component type | In YAML format | Notes |
+|---|---|---|
+| Entities (tables), attributes, forms, views | ✓ YAML files | Stored as individual YAML files per subcomponent |
+| Workflows (classic) | ✓ YAML files | Under `workflows/` |
+| Modern flows (Power Automate cloud flows) | ✓ — YAML format only | Under `modernflows/`; not supported in XML format |
+| Canvas apps | ✓ — YAML format only | `.msapp` binary under `canvasapps/<name>/`; not supported in XML format |
+| Environment variable definitions | ✓ XML files | Individual `.xml` files under `environmentvariabledefinitions/` |
+| Environment variable values | ✓ JSON file | Stored as `environment_variable_values.json` |
+| Custom connectors | ✓ | Under `connectors/` |
+| Plug-in assemblies | ✓ | Fully qualified type names remapped by default (`/remapPluginTypeNames`) |
+| Web resources | ✓ | Under `webresources/` |
+| Security roles | ✓ | Stored as XML internally; filtered per solution |
+| Option sets (global) | ✓ | Stored as XML; filtered per solution |
+| Dashboards | ✓ | Stored as XML; filtered per solution |
+| Site maps | ✓ | Stored as XML; filtered per solution |
+| Ribbon customizations | ✓ | Stored as XML; filtered per solution |
+| Entity relationships | ✓ | Under `entityrelationships/` |
+
+> [!NOTE]
+> Components stored as XML internally are automatically converted between XML and YAML during pack and unpack operations. You can author them as YAML files; the tool handles the conversion.
+
+## Multi-solution repositories
+
+A single repository root can contain multiple solutions. All solutions share the same component folders; `solutioncomponents.yml` in each solution controls which component paths belong to that solution.
+
+Example structure with two solutions:
+
+```
+<repositoryRoot>/
+├── solutions/
+│   ├── SolutionA/
+│   │   ├── solution.yml
+│   │   ├── solutioncomponents.yml    ← references entities/account, entities/contact
+│   │   ├── rootcomponents.yml
+│   │   └── missingdependencies.yml
+│   └── SolutionB/
+│       ├── solution.yml
+│       ├── solutioncomponents.yml    ← references entities/lead, workflows/myflow
+│       ├── rootcomponents.yml
+│       └── missingdependencies.yml
+├── publishers/
+│   └── SharedPublisher/
+│       └── publisher.yml
+├── entities/
+│   ├── account/
+│   ├── contact/
+│   └── lead/
+└── workflows/
+    └── myflow/
+```
+
+**Packing a specific solution from a multi-solution folder:**
+
+Using SolutionPackager.exe:
+```
+SolutionPackager.exe /action:Pack /zipfile:SolutionA.zip /folder:C:\repos\myrepo /SolutionName:SolutionA
+```
+
+Using `pac solution pack` (single-solution folders only — for multi-solution, use SolutionPackager.exe directly with `/SolutionName`):
+```powershell
+pac solution pack --zipfile SolutionA.zip --folder C:\repos\myrepo
+```
+
+> [!NOTE]
+> When using native Dataverse Git integration with **environment binding**, all solutions in the environment share a single repository root using the multi-solution layout. When using **solution binding**, each solution can be bound to a separate folder.
+
+## Working with YAML format folders
+
+### Pack a YAML folder into a .zip file
+
+```powershell
+# Using pac CLI (single solution in folder)
+pac solution pack --zipfile C:\output\MySolution.zip --folder C:\repos\myrepo
+
+# Using SolutionPackager.exe directly (also works for multi-solution with /SolutionName)
+SolutionPackager.exe /action:Pack /zipfile:C:\output\MySolution.zip /folder:C:\repos\myrepo
+```
+
+### Obtain a complete YAML folder from Dataverse
+
+The recommended way to get a complete, packable YAML folder is to use `pac solution clone`:
+
+```powershell
+pac solution clone --name MySolutionUniqueName --outputDirectory C:\repos\myrepo
+```
+
+This extracts the solution into the YAML format, including all component source files. Alternatively, use native Git integration to commit from Power Apps — the committed files are in YAML format and fully packable.
+
+### Verify the folder before packing
+
+Check that the `solutions/<name>/` folder exists and that all paths in `solutioncomponents.yml` resolve to actual files. Any missing paths result in warnings during pack and those components are omitted.
+
+## Relationship to Dataverse Git integration
+
+The YAML source control format is the canonical format used by [Dataverse Git integration](git-integration/overview.md). When makers commit solutions from Power Apps, the files written to Azure DevOps use this format. Code-first developers can work with the same repository using the CLI tools described here.
+
+For information about connecting environments to Git, see [Dataverse Git integration setup](git-integration/connecting-to-git.md).
+
+## Related content
+
+- [SolutionPackager tool](solution-packager-tool.md)
+- [Source control with solution files](use-source-control-solution-files.md)
+- [pac solution pack](../developer/cli/reference/solution.md#pac-solution-pack)
+- [pac solution unpack](../developer/cli/reference/solution.md#pac-solution-unpack)
+- [Dataverse Git integration overview](git-integration/overview.md)
+
+[!INCLUDE[footer-include](../includes/footer-banner.md)]

--- a/power-platform/alm/use-source-control-solution-files.md
+++ b/power-platform/alm/use-source-control-solution-files.md
@@ -14,17 +14,38 @@ search.audienceType:
 # Source control with solution files
 
 The Solution Packager tool can be used with any source control system. After a solution .zip file is extracted to a folder, add and submit the files to your source control system. These files can then be synchronized on another computer where they can be packed into a new identical solution .zip file.  
-  
+
 An important aspect when using extracted component files in source control is that adding all the files into source control might cause unnecessary duplication. Go to the [Solution Component File Reference](/powerapps/developer/common-data-service/solution-component-file-reference-solutionpackager) to discover which files are generated for each component type and which files are recommended for use in source control.  
-  
+
 As further customizations and changes are necessary for the solution, developers should edit or customize components through existing means, export again to create a .zip file, and extract the compressed solution file into the same folder.  
-  
+
 > [!IMPORTANT]
 > Except for the sections described in [When to edit the customizations file](when-edit-customization-file.md), manual editing of extracted component files and .zip files isn't supported.  
-  
+
 When the Solution Packager tool extracts the component files, it doesn't overwrite existing component files of the same name if the file contents are identical. In addition, the tool honors the read-only attribute on component files producing a warning in the console window that particular files weren't written. This protection enables the user to check out, from source control, the minimal set of files that are changing. The `/clobber` parameter can be used to override and cause read-only files to be written or deleted. The `/allowWrite` parameter can be used to assess what impact an extract operation has without actually causing any files to be written or deleted. Use of the `/allowWrite` parameter with verbose logging is effective.  
-  
+
 After the extract operation is completed with the minimal set of files checked out from source control, a developer can submit the changed files back into source control, as is done with any other type of source file.  
+
+## Source control file formats
+
+The Solution Packager tool supports two file formats for extracted component files. Choosing the right format up front avoids having to migrate your repository structure later.
+
+| | XML format (legacy) | YAML source control format |
+|---|---|---|
+| **Solution manifest** | `Other\Solution.xml` + `Other\Customizations.xml` | `solutions/<name>/solution.yml` and supporting YAML files |
+| **Readability** | Verbose XML | Compact YAML — easier to read and review |
+| **Diff quality in Git** | Large XML diffs | Minimal, focused diffs |
+| **Multi-solution repo** | Not supported | Supported — multiple solutions share one folder |
+| **Canvas apps (.msapp)** | Not supported | Supported |
+| **Modern flows** | Not supported | Supported |
+| **Native Git integration** | Not used | Always used — Git integration always writes YAML |
+
+**When to use the YAML format:** For all new projects, and whenever you use native [Dataverse Git integration](git-integration/overview.md). The YAML format is forward-compatible and produces cleaner change history.
+
+**When to use the XML format:** Only when working with existing repositories that already use the XML format, or when using legacy tooling that doesn't support YAML.
+
+> [!NOTE]
+> When you commit solutions using the native Git integration in Power Apps, they're always stored in the YAML source control format. To manually pack or unpack that source using SolutionPackager or `pac solution pack`, the folder must follow the YAML folder structure. More information: [SolutionPackager tool — Source control file formats](solution-packager-tool.md#source-control-file-formats)
   
 ## Team development  
 
@@ -133,7 +154,8 @@ The following procedure identifies the typical steps used when modifying an exis
 ### See also
 
  [Solution Component File Reference (SolutionPackager)](/powerapps/developer/common-data-service/solution-component-file-reference-solutionpackager)  
- [SolutionPackager tool](solution-packager-tool.md)
+ [SolutionPackager tool](solution-packager-tool.md)  
+ [Source control file formats](solution-packager-tool.md#source-control-file-formats)
 
 
 [!INCLUDE[footer-include](../includes/footer-banner.md)]

--- a/power-platform/developer/cli/reference/includes/solution-pack-remarks.md
+++ b/power-platform/developer/cli/reference/includes/solution-pack-remarks.md
@@ -1,8 +1,27 @@
-<!-- 
-Instructions: Remove comments and this line. Add appropriate remarks below
-
 ### Remarks
 
-Add remarks here...
+`pac solution pack` supports two source folder layouts when reading component files: the **XML format** (legacy) and the **YAML source control format**.
 
--->
+The format is auto-detected based on the folder contents:
+
+- If the folder contains a `solutions/` subdirectory with `*solution.yml` files → **YAML format** is used.
+- If no `solutions/` subdirectory is found → **XML format** (legacy) is used, which requires `Other\Solution.xml` and `Other\Customizations.xml`.
+
+**YAML format example:**
+
+```powershell
+pac solution pack --zipfile C:\output\MySolution.zip --folder C:\repos\myrepo
+```
+
+**Working with a multi-solution repository:**
+
+When the folder contains more than one solution under `solutions/*/solution.yml`, use the SolutionPackager.exe directly with `/SolutionName`:
+
+```
+SolutionPackager.exe /action:Pack /zipfile:SolutionA.zip /folder:C:\repos\myrepo /SolutionName:SolutionA
+```
+
+> [!NOTE]
+> The YAML source control format is the format written by native [Dataverse Git integration](../../alm/git-integration/overview.md) when you commit solutions from Power Apps. If you're manually packing a folder from a Git-integrated repository, use `pac solution pack` with the `--folder` pointing at the repository root.
+
+For more information about the YAML folder structure and which components are supported, see [SolutionPackager tool — Source control file formats](../../alm/solution-packager-tool.md#source-control-file-formats).

--- a/power-platform/developer/cli/reference/includes/solution-pack-remarks.md
+++ b/power-platform/developer/cli/reference/includes/solution-pack-remarks.md
@@ -2,6 +2,9 @@
 
 `pac solution pack` supports two source folder layouts when reading component files: the **XML format** (legacy) and the **YAML source control format**.
 
+> [!IMPORTANT]
+> YAML source control format support requires **Microsoft.PowerApps.CLI version 2.4.1 or later**. Download from [NuGet](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/2.4.1) or update with `pac install latest`.
+
 The format is auto-detected based on the folder contents:
 
 - If the folder contains a `solutions/` subdirectory with `*solution.yml` files → **YAML format** is used.

--- a/power-platform/developer/cli/reference/includes/solution-unpack-remarks.md
+++ b/power-platform/developer/cli/reference/includes/solution-unpack-remarks.md
@@ -1,8 +1,26 @@
-<!-- 
-Instructions: Remove comments and this line. Add appropriate remarks below
-
 ### Remarks
 
-Add remarks here...
+`pac solution unpack` extracts solution components from a `.zip` file into the **XML format** by default, creating an `Other\Solution.xml` hierarchy.
 
--->
+When working with solutions managed via native [Dataverse Git integration](../../alm/git-integration/overview.md) or extracted via `pac solution clone`, the resulting folder uses the **YAML source control format** instead:
+
+```
+<folder>/
+├── solutions/
+│   └── <SolutionUniqueName>/
+│       ├── solution.yml
+│       ├── solutioncomponents.yml
+│       ├── rootcomponents.yml
+│       └── missingdependencies.yml
+├── publishers/
+│   └── <PublisherUniqueName>/
+│       └── publisher.yml
+└── [component folders — entities/, workflows/, canvasapps/, ...]
+```
+
+To repack a folder in this YAML layout, use `pac solution pack --folder <rootFolder>` — the YAML format is detected automatically from the presence of the `solutions/` subdirectory.
+
+> [!IMPORTANT]
+> If a component is listed in `rootcomponents.yml` but its source files aren't present in the folder (for example, a canvas app `.msapp` file under `canvasapps/<name>/`), the pack operation still succeeds but that component is omitted from the output `.zip`. Re-export and unpack the full solution from Dataverse to ensure all component files are present.
+
+For more information about the YAML folder structure and component support, see [SolutionPackager tool — Source control file formats](../../alm/solution-packager-tool.md#source-control-file-formats).

--- a/power-platform/developer/cli/reference/includes/solution-unpack-remarks.md
+++ b/power-platform/developer/cli/reference/includes/solution-unpack-remarks.md
@@ -2,6 +2,9 @@
 
 `pac solution unpack` extracts solution components from a `.zip` file into the **XML format** by default, creating an `Other\Solution.xml` hierarchy.
 
+> [!IMPORTANT]
+> YAML source control format support requires **Microsoft.PowerApps.CLI version 2.4.1 or later**. Download from [NuGet](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/2.4.1) or update with `pac install latest`.
+
 When working with solutions managed via native [Dataverse Git integration](../../alm/git-integration/overview.md) or extracted via `pac solution clone`, the resulting folder uses the **YAML source control format** instead:
 
 ```


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for the YAML-based source control format introduced in SolutionPackager / pac CLI (v2.4.1+), which is also the format produced by Dataverse Git integration. This format has been available but entirely undocumented in Microsoft Learn.

## Changes

### 1. lm/solution-packager-tool.md
- Added /SolutionName and /remapPluginTypeNames arguments to the arguments table
- Added **"Source control file formats"** section covering:
  - XML vs YAML format comparison
  - Required folder structure with directory tree
  - Format auto-detection rules
  - Component support table (canvas apps and modern flows: YAML only)
  - Multi-solution repository example and CLI commands
- Added **2 new Troubleshooting entries**:
  - Misleading Cannot find Customizations.xml error when YAML files are in wrong location
  - Missing component source file warning (exit code 0, component omitted)

### 2. lm/use-source-control-solution-files.md
- Added "Source control file formats" comparison table (XML vs YAML)
- Added guidance on when to use each format
- Updated See also links

### 3. developer/cli/reference/includes/solution-pack-remarks.md *(was empty placeholder)*
- YAML vs XML auto-detection explanation
- YAML format example and multi-solution note
- Version requirement callout (pac CLI 2.4.1+)

### 4. developer/cli/reference/includes/solution-unpack-remarks.md *(was empty placeholder)*
- YAML folder structure output diagram
- Repack guidance
- Missing component source file warning
- Version requirement callout (pac CLI 2.4.1+)

### 5. lm/solution-source-control-yaml-format.md *(new page)*
- Complete standalone reference for the YAML format
- Full folder structure with all required directories
- All manifest files documented (solution.yml, solutioncomponents.yml, rootcomponents.yml, missingdependencies.yml, publisher.yml)
- Component type support table
- Multi-solution repository layout
- How-to commands for packing, cloning, and verifying

### 6. lm/TOC.yml
- New navigation entry: "Solution YAML source control format" under "Leverage solution and packaging tools"

### 7. lm/git-integration/faqs.md
- New FAQ: "What folder structure does the YAML source control format use?"
- Updated "How can I upgrade existing solutions?" with link to SolutionPackager YAML section

## Motivation

Discovered during investigation of a user error: when a solution is exported and only the YAML root files exist (without the required solutions/<name>/ subfolder), SolutionPackager produces a misleading error about Customizations.xml. Users have no documentation to understand the expected structure or how to fix the issue.

## Version requirement

All pac CLI YAML functionality requires **Microsoft.PowerApps.CLI 2.4.1+** — noted in relevant articles with NuGet link.