### PR TITLE
Add new datacenter region for Sweden

### DIFF
--- a/power-platform/admin/new-datacenter-regions.md
+++ b/power-platform/admin/new-datacenter-regions.md
@@ -46,6 +46,7 @@ The following is a list of regions and their URL for Dynamics 365 (Dynamics 365 
 | NOR           | crm19.dynamics.com |
 | SGP           | crm20.dynamics.com |
 | KOR           | crm21.dynamics.com |
+| SWE           | crm22.dynamics.com |
 
 ## Migration process  
  This is the overall process for migrating to a new datacenter.  


### PR DESCRIPTION
**Description**
This PR adds Sweden (SWE) as a supported datacenter region with its corresponding Dynamics 365 endpoint: crm22.dynamics.com

**Motivation**
Sweden is currently an active and supported region in Power Platform / Dynamics 365 (e.g. environments using crm22.dynamics.com), but it is not listed in this documentation.

This can lead to:
- Confusion when identifying region endpoints
- Issues when configuring allow-lists or integrations (e.g. Fabric, networking, security policies)
- Uncertainty during compliance and data residency reviews

**Validation**
- Environments are actively provisioned using *.crm22.dynamics.com
- The region corresponds to Microsoft’s Sweden datacenter region (Sweden Central)
- Behaviour is consistent with other documented regions

**Impact**
This change improves:
- Accuracy of official documentation
- Discoverability of Sweden as a supported region
- Developer and administration experience when working with regional endpoints