### PR TITLE
Update author link for Nick Talsma

### DIFF
--- a/power-platform/architecture/reference-architectures/enterprise-power-platform-alm.md
+++ b/power-platform/architecture/reference-architectures/enterprise-power-platform-alm.md
@@ -245,7 +245,7 @@ _Microsoft maintains this article. The following contributors wrote this article
 
 **Principal authors**:
 
-- **[Nick Talsma](https://www.linkedin.com/in/biswapm/)**, Power Platform Technical Architect
+- **[Nick Talsma](https://www.linkedin.com/in/nick-talsma/)**, Power Platform Technical Architect
 
 ## Related resources
 


### PR DESCRIPTION
This PR corrects the public contributor attribution for the article. Name was correct but linked to the wrong person.

No technical content changes are included in this PR.