### PR TITLE
Fix dead links to troubleshooting-monitoring-server-side-synchronization

### DIFF
--- a/power-platform/admin/best-practices-server-side-synchronization.md
+++ b/power-platform/admin/best-practices-server-side-synchronization.md
@@ -99,7 +99,7 @@ To set the synchronization method to none for nonproduction environments:
 ### See also
 
 [Server-side synchronization](../admin/server-side-synchronization.md)  
-[Troubleshooting server-side synchronization](../admin/troubleshooting-monitoring-server-side-synchronization.md)   
+[Troubleshooting server-side synchronization](/troubleshoot/power-platform/dataverse/email-exchange-synchronization/troubleshooting-monitoring-server-side-synchronization)   
 
 
 [!INCLUDE[footer-include](../includes/footer-banner.md)]

--- a/power-platform/admin/connect-exchange-online.md
+++ b/power-platform/admin/connect-exchange-online.md
@@ -329,7 +329,7 @@ To see alerts for an individual mailbox, open the mailbox, and then under **Comm
   
 The result of the email configuration test is displayed in the **Incoming Email Status**, **Outgoing Email Status**, and **Appointments, Contacts, and Tasks Status** columns of a mailbox record. An alert is also generated when the configuration is successfully completed for a mailbox. This alert is shown to the mailbox owner.  
   
-You can find information about recurring issues and other troubleshooting information in [Blog: Test and Enable Mailboxes in Microsoft Dynamics CRM 2015](https://cloudblogs.microsoft.com/dynamics365/no-audience/2015/08/31/test-and-enable-mailboxes-in-microsoft-dynamics-crm-2015/) and [Troubleshooting and monitoring server-side synchronization](../admin/troubleshooting-monitoring-server-side-synchronization.md).  
+You can find information about recurring issues and other troubleshooting information in [Blog: Test and Enable Mailboxes in Microsoft Dynamics CRM 2015](https://cloudblogs.microsoft.com/dynamics365/no-audience/2015/08/31/test-and-enable-mailboxes-in-microsoft-dynamics-crm-2015/) and [Troubleshooting and monitoring server-side synchronization](/troubleshoot/power-platform/dataverse/email-exchange-synchronization/troubleshooting-monitoring-server-side-synchronization).  
   
 Make sure you've got a good connection to [!INCLUDE[pn_Exchange_Online](../includes/pn-exchange-online.md)] by running the [Microsoft Remote Connectivity Analyzer](https://testconnectivity.microsoft.com/). For information about what tests to run, see [Test mail flow with the Remote Connectivity Analyzer](https://technet.microsoft.com/library/dn305950\(v=exchg.150\).aspx).
   
@@ -362,7 +362,7 @@ Set-CrmRecord -conn $conn -CrmRecord $emailserverprofile
 
 ### See also
 
-[Troubleshooting and monitoring server-side synchronization](../admin/troubleshooting-monitoring-server-side-synchronization.md) <br />
+[Troubleshooting and monitoring server-side synchronization](/troubleshoot/power-platform/dataverse/email-exchange-synchronization/troubleshooting-monitoring-server-side-synchronization) <br />
 [Test mail flow by validating your connectors](/exchange/mail-flow-best-practices/test-mail-flow)
 
 [!INCLUDE[footer-include](../includes/footer-banner.md)]

--- a/power-platform/admin/connect-exchange-server-on-premises.md
+++ b/power-platform/admin/connect-exchange-server-on-premises.md
@@ -188,7 +188,7 @@ When you test the email configuration, an asynchronous job runs in the backgroun
 
 ### See also
 
-- [Troubleshooting and monitoring server-side synchronization](troubleshooting-monitoring-server-side-synchronization.md)
+- [Troubleshooting and monitoring server-side synchronization](/troubleshoot/power-platform/dataverse/email-exchange-synchronization/troubleshooting-monitoring-server-side-synchronization)
 - [Test mail flow with the Remote Connectivity Analyzer](https://technet.microsoft.com/library/dn305950\(v=exchg.150\).aspx)
 - [Server-side synchronization](server-side-synchronization.md)
 - [Autodiscover service](https://technet.microsoft.com/library/bb124251\(v=exchg.150\).aspx)

--- a/power-platform/admin/connect-to-imap-servers.md
+++ b/power-platform/admin/connect-to-imap-servers.md
@@ -164,7 +164,7 @@ To see configuration test results, look at the **Incoming Email Status**, **Outg
 You can find information about recurring issues and other troubleshooting information in the following topics:
 
 - [Test configuration of mailboxes](connect-exchange-online.md#test-the-configuration-of-mailboxes).
-- [Troubleshooting and monitoring server-side synchronization](troubleshooting-monitoring-server-side-synchronization.md).
+- [Troubleshooting and monitoring server-side synchronization](/troubleshoot/power-platform/dataverse/email-exchange-synchronization/troubleshooting-monitoring-server-side-synchronization).
 
 ## Test email configurations  
 
@@ -194,7 +194,7 @@ Customizations or email configurations in Power Apps can only use these ports.
 
 ### See also
 
-[Troubleshooting and monitoring server-side synchronization](troubleshooting-monitoring-server-side-synchronization.md) <br />
+[Troubleshooting and monitoring server-side synchronization](/troubleshoot/power-platform/dataverse/email-exchange-synchronization/troubleshooting-monitoring-server-side-synchronization) <br />
 [Test mail flow with the Remote Connectivity Analyzer](https://technet.microsoft.com/library/dn305950\(v=exchg.150\).aspx) <br />
 [Set up server-side synchronization](set-up-server-side-synchronization-of-email-appointments-contacts-and-tasks.md)
 

--- a/power-platform/admin/connect-to-pop3-or-smtp-servers.md
+++ b/power-platform/admin/connect-to-pop3-or-smtp-servers.md
@@ -153,7 +153,7 @@ This tests the incoming and outgoing configurations of selected mailboxes and en
 
 To see email configuration test results, look at the **Incoming Email Status**, **Outgoing Email Status**, and **Appointments, Contacts, and Tasks Status** fields of a mailbox record. Each successful configuration for a mailbox also generates an alert for you and the mailbox owner.
 
-You can find information about recurring issues and other troubleshooting information in [Blog: Test and Enable Mailboxes in Microsoft Dynamics CRM 2015](https://blogs.msdn.com/b/crm/archive/2015/08/31/test-and-enable-mailboxes-in-microsoft-dynamics-crm-2015.aspx) and [Troubleshooting and monitoring server-side synchronization](troubleshooting-monitoring-server-side-synchronization.md).  
+You can find information about recurring issues and other troubleshooting information in [Blog: Test and Enable Mailboxes in Microsoft Dynamics CRM 2015](https://blogs.msdn.com/b/crm/archive/2015/08/31/test-and-enable-mailboxes-in-microsoft-dynamics-crm-2015.aspx) and [Troubleshooting and monitoring server-side synchronization](/troubleshoot/power-platform/dataverse/email-exchange-synchronization/troubleshooting-monitoring-server-side-synchronization).  
 
 > [!TIP]
 > If you're unable to synchronize contacts, appointments, and tasks for a mailbox, you might want to select the **Sync items with Exchange from this org only, even if Exchange was set to sync with a different org** checkbox. More information: [When would I want to use this check box?](when-would-want-use-check-box.md)
@@ -181,7 +181,7 @@ Customizations or email configurations in Power Apps US Government can only use 
 
 ### See also
 
-[Troubleshooting and monitoring server-side synchronization](troubleshooting-monitoring-server-side-synchronization.md) <br />
+[Troubleshooting and monitoring server-side synchronization](/troubleshoot/power-platform/dataverse/email-exchange-synchronization/troubleshooting-monitoring-server-side-synchronization) <br />
 [Test mail flow with the Remote Connectivity Analyzer](https://technet.microsoft.com/library/dn305950\(v=exchg.150\).aspx) <br />
 [Microsoft Power Apps US Government](powerapps-us-government.md)
 

--- a/power-platform/admin/frequently-asked-questions-synchronizing-records-dynamics-365-and-outlook.yml
+++ b/power-platform/admin/frequently-asked-questions-synchronizing-records-dynamics-365-and-outlook.yml
@@ -44,7 +44,7 @@ sections:
       - question: |
           Where can I find information on troubleshooting server-side synchronization issues?  
         answer: |
-           You can find information on troubleshooting and known issues here: [Troubleshooting and things to know about server-side synchronization](../admin/troubleshooting-monitoring-server-side-synchronization.md).  
+           You can find information on troubleshooting and known issues here: [Troubleshooting and things to know about server-side synchronization](/troubleshoot/power-platform/dataverse/email-exchange-synchronization/troubleshooting-monitoring-server-side-synchronization).  
             
       - question: |
           Do security permissions affect synchronization?  

--- a/power-platform/admin/integrate-synchronize-your-email-system.md
+++ b/power-platform/admin/integrate-synchronize-your-email-system.md
@@ -56,7 +56,7 @@ One of the main reasons people use customer engagement apps (Dynamics 365 Sales,
 ### See also  
  [Microsoft Dynamics CRM: How it works documentation ](https://www.microsoft.com/download/details.aspx?id=48718) 
  [Integrate your email system using server-side synchronization](../admin/set-up-server-side-synchronization-of-email-appointments-contacts-and-tasks.md)   
- [Troubleshooting and monitoring server-side synchronization issues](../admin/troubleshooting-monitoring-server-side-synchronization.md)   
+ [Troubleshooting and monitoring server-side synchronization issues](/troubleshoot/power-platform/dataverse/email-exchange-synchronization/troubleshooting-monitoring-server-side-synchronization)   
  [Deploy Dynamics 365 App for Outlook](/dynamics365/outlook-app/deploy-dynamics-365-app-for-outlook)   
 
  

--- a/power-platform/admin/server-side-synchronization.md
+++ b/power-platform/admin/server-side-synchronization.md
@@ -85,7 +85,7 @@ If the mailbox is enabled for appointments, contacts, and tasks and incoming ema
   
 - **Service isolation**: Server-side synchronization has separate queue-management and configuration settings for asynchronous operations, outgoing activities, and mailboxes. It's based off of asynchronous service architecture and might share the same process. In all cases, it manages server resources while maintaining isolation with the asynchronous service.  
   
-- **Error reporting for users and administrators**: Server-side synchronization supports logging and reporting of errors specific to an email or one or more mailboxes. [!INCLUDE[proc_more_information](../includes/proc-more-information.md)] [Error logging for server-side synchronization](troubleshooting-monitoring-server-side-synchronization.md)  
+- **Error reporting for users and administrators**: Server-side synchronization supports logging and reporting of errors specific to an email or one or more mailboxes. [!INCLUDE[proc_more_information](../includes/proc-more-information.md)] [Error logging for server-side synchronization](/troubleshoot/power-platform/dataverse/email-exchange-synchronization/troubleshooting-monitoring-server-side-synchronization)  
   
 > [!NOTE]
 > In customer engagement apps, you can synchronize emails by using [!INCLUDE[pn_crm_for_outlook_short](../includes/pn-crm-for-outlook-short.md)] or server-side synchronization. If server-side synchronization is selected, the synchronization doesn't require that you run [!INCLUDE[pn_crm_for_outlook_short](../includes/pn-crm-for-outlook-short.md)]. However, you'll still need [!INCLUDE[pn_crm_for_outlook_short](../includes/pn-crm-for-outlook-short.md)] to promote an item from [!INCLUDE[pn_Outlook_short](../includes/pn-outlook-short.md)].  

--- a/power-platform/admin/set-up-server-side-synchronization-of-email-appointments-contacts-and-tasks.md
+++ b/power-platform/admin/set-up-server-side-synchronization-of-email-appointments-contacts-and-tasks.md
@@ -34,7 +34,7 @@ Choose one of the following scenarios to configure server-side synchronization f
 
 ### See also  
 [Server-side synchronization](../admin/server-side-synchronization.md) 
-[Troubleshooting server-side synchronization](../admin/troubleshooting-monitoring-server-side-synchronization.md)   
+[Troubleshooting server-side synchronization](/troubleshoot/power-platform/dataverse/email-exchange-synchronization/troubleshooting-monitoring-server-side-synchronization)   
 
 
 [!INCLUDE[footer-include](../includes/footer-banner.md)]


### PR DESCRIPTION
## Summary
- `troubleshooting-monitoring-server-side-synchronization.md` doesn't exist anywhere in this repo, but 9 admin articles link to it with a relative `.md` path, so every one of those links 404s
- Confirmed the content actually moved to the `SupportArticles-docs-pr` repo and is now published at `/troubleshoot/power-platform/dataverse/email-exchange-synchronization/troubleshooting-monitoring-server-side-synchronization` (verified live on learn.microsoft.com)
- Repointed all 12 occurrences (some files link to it twice) to that absolute URL, since a relative link can't reach across repos

## Files changed
- admin/best-practices-server-side-synchronization.md
- admin/connect-exchange-online.md (2 instances)
- admin/connect-exchange-server-on-premises.md
- admin/connect-to-imap-servers.md (2 instances)
- admin/connect-to-pop3-or-smtp-servers.md (2 instances)
- admin/frequently-asked-questions-synchronizing-records-dynamics-365-and-outlook.yml
- admin/integrate-synchronize-your-email-system.md
- admin/server-side-synchronization.md
- admin/set-up-server-side-synchronization-of-email-appointments-contacts-and-tasks.md

## Test plan
- [x] Verified the new target URL is live and returns the correct content
- [x] Confirmed the old target doesn't exist anywhere in this repo (was fully removed, not just renamed)
- [x] Text-only link changes, no other content modified