### PR TITLE
Fix dead links to troubleshooting-user-needs-read-write-access-organization

### DIFF
--- a/power-platform/admin/database-security-configure.md
+++ b/power-platform/admin/database-security-configure.md
@@ -138,7 +138,7 @@ For environments with no Dataverse database, a user who has the Environment Admi
 
 ## Assign security roles to users in an environment that has a Dataverse database
 
-Security roles can be assigned to individual users, [owner teams](manage-teams.md#types-of-teams), and [Microsoft Entra group teams](manage-group-teams.md). Before you assign a role to a user, [verify the user's account is added to and enabled in the environment](troubleshooting-user-needs-read-write-access-organization.md).
+Security roles can be assigned to individual users, [owner teams](manage-teams.md#types-of-teams), and [Microsoft Entra group teams](manage-group-teams.md). Before you assign a role to a user, [verify the user's account is added to and enabled in the environment](/troubleshoot/power-platform/dataverse/environment-app-access/troubleshooting-user-needs-read-write-access-organization).
 
 In general, a security role can only be assigned to users whose accounts are enabled in the environment. To assign a security role to a user account disabled in the environment, turn on **allowRoleAssignmentOnDisabledUsers** in OrgDBOrgSettings.
 

--- a/power-platform/admin/database-security.md
+++ b/power-platform/admin/database-security.md
@@ -42,7 +42,7 @@ Microsoft Power Platform uses different types of roles at different scopes. Unde
 > [!IMPORTANT]
 > Tenant-level admin roles such as **Power Platform administrator** and **Dynamics 365 administrator** are assigned in the Microsoft 365 admin center and grant administrative access across environments. However, these roles don't automatically grant Dataverse data access. To work with data in a Dataverse environment, a tenant admin must also be assigned the **System Administrator** Dataverse security role in that specific environment. Learn more in [Use service admin roles to manage your tenant](use-service-admin-role-manage-tenant.md).
 
-Use this article to understand built-in roles and how they apply to different environment types. To assign roles, see [Configure user security in an environment](database-security-configure.md). If users encounter access errors, see [Troubleshoot user access problems](troubleshooting-user-needs-read-write-access-organization.md).
+Use this article to understand built-in roles and how they apply to different environment types. To assign roles, see [Configure user security in an environment](database-security-configure.md). If users encounter access errors, see [Troubleshoot user access problems](/troubleshoot/power-platform/dataverse/environment-app-access/troubleshooting-user-needs-read-write-access-organization).
 
 ## Predefined security roles
 
@@ -151,7 +151,7 @@ The following table describes common security role issues and how to resolve the
 | Can't assign or modify security roles | Only users with the System Administrator role or a tenant-level admin role can manage security role assignments. | Contact your organization's System Administrator or Microsoft 365 admin to request role changes. Learn more in [Configure user security in an environment](database-security-configure.md). |
 | Can't copy a security role | The security role is a predefined role that can't be edited or copied, or you don't have sufficient privileges. | Verify that you have the System Administrator role. Some predefined roles can't be copied. Try [creating a custom security role](security-roles-privileges.md) instead. |
 
-If these steps don't resolve your issue, see [Troubleshoot user access problems](troubleshooting-user-needs-read-write-access-organization.md) for more scenarios. If you need access changes, contact the appropriate admin:
+If these steps don't resolve your issue, see [Troubleshoot user access problems](/troubleshoot/power-platform/dataverse/environment-app-access/troubleshooting-user-needs-read-write-access-organization) for more scenarios. If you need access changes, contact the appropriate admin:
 
 - **Environment access**: Contact the environment admin or a user with the System Administrator role in that environment.
 - **Dataverse table or app access**: Contact a System Administrator in that environment to assign or update your security role.
@@ -163,7 +163,7 @@ If these steps don't resolve your issue, see [Troubleshoot user access problems]
 - [Security roles and privileges](security-roles-privileges.md)  
 - [How access to a record is determined](how-record-access-determined.md)
 - [Configure user security in an environment](database-security-configure.md)
-- [Troubleshoot user access problems](troubleshooting-user-needs-read-write-access-organization.md)
+- [Troubleshoot user access problems](/troubleshoot/power-platform/dataverse/environment-app-access/troubleshooting-user-needs-read-write-access-organization)
 - [Use service admin roles to manage your tenant](use-service-admin-role-manage-tenant.md)
 - [Security concepts in Microsoft Dataverse](/power-platform/admin/wp-security-cds)
 

--- a/power-platform/admin/delete-users.md
+++ b/power-platform/admin/delete-users.md
@@ -51,7 +51,7 @@ The following lists the scenarios when a user is deleted:
 - If the user is in the environment and has a status of **Disabled**, the status remains as **Disabled**.
 - If the user isn't present in the environment, no action is taken.
 
-It can take from 30 minutes to 6 hours for a user's status to be updated in an environment after the user is deleted from the Microsoft 365 admin center. If you need to update the user status immediately, you can follow the steps in [User diagnostics](troubleshooting-user-needs-read-write-access-organization.md#user-diagnostics) to see what needs to be done to restore the user.
+It can take from 30 minutes to 6 hours for a user's status to be updated in an environment after the user is deleted from the Microsoft 365 admin center. If you need to update the user status immediately, you can follow the steps in [User diagnostics](/troubleshoot/power-platform/dataverse/environment-app-access/troubleshooting-user-needs-read-write-access-organization#run-user-diagnostics) to see what needs to be done to restore the user.
 
 > [!NOTE]
 > A user deleted from the Microsoft 365 admin center is put on the **Deleted user** list for thirty days and can be restored as mentioned in next section.
@@ -341,6 +341,6 @@ If you enabled Dataverse auditing in the environment and in the **User** table, 
 [Delete stub users from an environment](delete-stub-users.md)
 [Delete unlicensed or removed Microsoft Entra group members](delete-unlicensed-or-removed-microsoft-entra-group-users.md)
 [Delete a user from your organization](/microsoft-365/admin/add-users/delete-a-user?view=o365-worldwide&preserve-view=true) <br />
-[Troubleshooting: Common user access issues](troubleshooting-user-needs-read-write-access-organization.md) <br />
+[Troubleshooting: Common user access issues](/troubleshoot/power-platform/dataverse/environment-app-access/troubleshooting-user-needs-read-write-access-organization) <br />
 
 [!INCLUDE[footer-include](../includes/footer-banner.md)]

--- a/power-platform/admin/users-settings.md
+++ b/power-platform/admin/users-settings.md
@@ -29,7 +29,7 @@ Manage user settings in the Power Platform admin center.
 
    | Option | Description | For more information |
    | ------- | ----------- | -------------------- |
-   | Run diagnostics | Access diagnostics on a user in an environment. | [User diagnostics](troubleshooting-user-needs-read-write-access-organization.md#user-diagnostics) |
+   | Run diagnostics | Access diagnostics on a user in an environment. | [User diagnostics](/troubleshoot/power-platform/dataverse/environment-app-access/troubleshooting-user-needs-read-write-access-organization#run-user-diagnostics) |
    | Manage security roles | Assign security roles to users to control access to data, using access levels and permissions.| [Assign a security role to a user](assign-security-roles.md) |
    | Refresh user | Resync the **User** page from Microsoft Entra ID. | |
    | Change position | Assign a position to a user. | [Hierarchy security to control access](hierarchy-security.md) |


### PR DESCRIPTION
## Summary
- `troubleshooting-user-needs-read-write-access-organization.md` doesn't exist anywhere in this repo, but 4 admin articles link to it with a relative `.md` path (7 occurrences total)
- Confirmed the content moved to the `SupportArticles-docs-pr` repo and is now published at `/troubleshoot/power-platform/dataverse/environment-app-access/troubleshooting-user-needs-read-write-access-organization` (verified live on learn.microsoft.com)
- Two occurrences also referenced a `#user-diagnostics` anchor; the current article's matching heading is "Run user diagnostics", so those anchors are updated to `#run-user-diagnostics`

## Files changed
- admin/database-security-configure.md
- admin/database-security.md (3 instances)
- admin/delete-users.md (2 instances, 1 with anchor)
- admin/users-settings.md (1 instance, with anchor)

## Test plan
- [x] Verified the new target URL is live and returns the correct content
- [x] Verified the "Run user diagnostics" heading exists at the new URL and matches the old #user-diagnostics anchor's intent
- [x] Confirmed the old target doesn't exist anywhere in this repo
- [x] Text-only link changes, no other content modified