### PR TITLE
Fix dead links to troubleshoot-set-up-sharepoint-online

### DIFF
--- a/power-platform/admin/permissions-required-document-management-tasks.md
+++ b/power-platform/admin/permissions-required-document-management-tasks.md
@@ -32,7 +32,7 @@ The following table shows the default security roles or other permissions that a
   
 ### Related content
  [Manage Your Documents](../admin/manage-documents-using-sharepoint.md) <br /> 
-[Validate and fix SharePoint site URLs](troubleshoot-set-up-sharepoint-online.md#validate-and-fix-sharepoint-site-urls)
+[Validate and fix SharePoint site URLs](/troubleshoot/power-platform/power-apps/integrate-products/troubleshoot-set-up-sharepoint-online#validate-and-fix-sharepoint-site-urls)
 
 
 

--- a/power-platform/admin/set-up-sharepoint-integration.md
+++ b/power-platform/admin/set-up-sharepoint-integration.md
@@ -31,7 +31,7 @@ With SharePoint you can store and manage documents in the context of a record on
 
  [Manage your documents](../admin/manage-documents-using-sharepoint.md)  <br /> 
  [Permissions required for document management tasks](../admin/permissions-required-document-management-tasks.md)   <br />
- [Validate and fix SharePoint site URLs](troubleshoot-set-up-sharepoint-online.md#validate-and-fix-sharepoint-site-urls) <br />
+ [Validate and fix SharePoint site URLs](/troubleshoot/power-platform/power-apps/integrate-products/troubleshoot-set-up-sharepoint-online#validate-and-fix-sharepoint-site-urls) <br />
  [Enable SharePoint document management for specific entities](enable-sharepoint-document-management-specific-entities.md)
 
 


### PR DESCRIPTION
## Summary
- `troubleshoot-set-up-sharepoint-online.md` doesn't exist anywhere in this repo, but 2 admin articles link to it with a relative `.md` path
- Confirmed the content moved to the `SupportArticles-docs-pr` repo and is now published at `/troubleshoot/power-platform/power-apps/integrate-products/troubleshoot-set-up-sharepoint-online` (verified live on learn.microsoft.com)
- The `#validate-and-fix-sharepoint-site-urls` anchor still matches a heading on the current article, so only the base path changes

## Files changed
- admin/set-up-sharepoint-integration.md
- admin/permissions-required-document-management-tasks.md

## Test plan
- [x] Verified the new target URL is live and returns the correct content
- [x] Verified the anchor `#validate-and-fix-sharepoint-site-urls` matches a real heading on the current article
- [x] Confirmed the old target doesn't exist anywhere in this repo
- [x] Text-only link changes, no other content modified