### PR TITLE
Fix dead links to logging-powerapps.md

### DIFF
--- a/power-platform/admin/governance-considerations.md
+++ b/power-platform/admin/governance-considerations.md
@@ -152,7 +152,7 @@ It's well understood that monitoring is a critical aspect of managing software a
 
 ### Review the audit trail
 
-[Activity logging for Power Apps](logging-powerapps.md) is integrated with Office Security and Compliance center for comprehensive logging across Microsoft services like Dataverse and Microsoft 365. Office provides an API to query this data, which is currently used by many SIEM vendors to use the Activity Logging data for reporting.
+[Activity logging for Power Apps](activity-logging-auditing/activity-logs-power-apps.md) is integrated with Office Security and Compliance center for comprehensive logging across Microsoft services like Dataverse and Microsoft 365. Office provides an API to query this data, which is currently used by many SIEM vendors to use the Activity Logging data for reporting.
 
 ### View the Power Apps and Power Automate license report
 

--- a/power-platform/admin/miscellaneous-privileges.md
+++ b/power-platform/admin/miscellaneous-privileges.md
@@ -85,6 +85,6 @@ The following table describes the miscellaneous privileges, which in the new, mo
 | Use internet marketing module | prvUseInternetMarketing | [Create a quick campaign using in-app marketing (Sales)](/dynamics365/customerengagement/on-premises/developer/sample-distribute-a-quick-campaign) |
 | View Audit History | prvReadRecordAuditHistory | [Audit history](dataverse-privacy-dsr-guide.md#audit-history) |
 | View Audit Partitions | prvReadAuditPartitions | [Audit data and user activity for security and compliance](manage-dataverse-auditing.md) |
-| View Audit Summary | prvReadAuditSummary | [Power Apps activity logging](logging-powerapps.md) |
+| View Audit Summary | prvReadAuditSummary | [Power Apps activity logging](activity-logging-auditing/activity-logs-power-apps.md) |
 | Web Mail Merge | prvWebMailMerge | [Work with mail merge templates](work-mail-merge-templates.md) |
 | Write own calendar | prvWriteOwnCalendar | Not applicable |


### PR DESCRIPTION
## Summary
- `logging-powerapps.md` doesn't exist anywhere in this repo, but 2 admin articles link to it with a relative `.md` path
- Confirmed the content was reorganized within this same repo into `admin/activity-logging-auditing/activity-logs-power-apps.md` (title: "View Power Apps activity logs in Microsoft Purview") — this is an in-repo rename, not a cross-repo move like the last few PRs
- Repointed both occurrences to the new relative path

## Files changed
- admin/governance-considerations.md
- admin/miscellaneous-privileges.md

## Test plan
- [x] Verified the new target file exists at the resolved relative path
- [x] Confirmed the old target doesn't exist anywhere in this repo
- [x] Text-only link changes, no other content modified