### PR TITLE
Fix trailing comma in mcp.json example

### DIFF
--- a/power-platform/developer/howto/use-mcp.md
+++ b/power-platform/developer/howto/use-mcp.md
@@ -81,7 +81,7 @@ If you're editing `mcp.json` file manually, MCP server registration should look 
       "type": "stdio",
       "command": "dnx",
       "args": ["Microsoft.PowerApps.CLI.Tool", "--yes", "copilot", "mcp", "--run"]
-    },
+    }
   }
 }
 ```


### PR DESCRIPTION
## Summary
- `developer/howto/use-mcp.md` has a manual `mcp.json` configuration example under the Visual Studio section with a trailing comma after the `pac-mcp` server entry, making the block invalid JSON
- A reader copying this example verbatim into their `mcp.json` file gets a parse error
- Removed the trailing comma; verified the block now parses as valid JSON

## Test plan
- [x] Confirmed the block fails `json.loads()` before the fix and succeeds after
- [x] One-character diff, no other content changed