### PR TITLE
Fix transactionless copy PowerShell syntax

### DIFF
--- a/power-platform/admin/unified-experience/tutorial-perform-transactionless-copy.md
+++ b/power-platform/admin/unified-experience/tutorial-perform-transactionless-copy.md
@@ -83,13 +83,13 @@ Write-Host "Creating a session against the Power Platform API"
 
 Add-PowerAppsAccount -Endpoint prod -TenantID $TenantId -ApplicationId $SPNId -ClientSecret $ClientSecret
 
-    $copyToRequest = \[pscustomobject\]@{
-        SourceEnvironmentId = $SourceEnvironmentID
-        TargetEnvironmentName = "Copied from source"
-        CopyType = "FullCopy"
-        SkipAuditData = true
-        ExecuteAdvancedCopyForFinanceAndOperations = true
-    }
+$copyToRequest = [PSCustomObject]@{
+    SourceEnvironmentId = $SourceEnvironmentID
+    TargetEnvironmentName = "Copied from source"
+    CopyType = "FullCopy"
+    SkipAuditData = $true
+    ExecuteAdvancedCopyForFinanceAndOperations = $true
+}
 
 Copy-PowerAppEnvironment -EnvironmentName $TargetEnvironmentID -CopyToRequestDefinition $copyToRequest
 ```


### PR DESCRIPTION
Refreshes and applies the valid correction from #2706 against current `main`.

- Removes escaped PowerShell type syntax.
- Uses `$true` for Boolean values.
- Corrects hashtable assignment syntax and indentation.

Closes #2706. Supersedes duplicate #2707.