### PR TITLE
Correct cross-tenant report API links

### DIFF
--- a/power-platform/admin/programmability-tutorial-cross-tenant-reporting.md
+++ b/power-platform/admin/programmability-tutorial-cross-tenant-reporting.md
@@ -113,7 +113,7 @@ try
 }
 ```
 
-Power Platform API reference: [Get Cross-Tenant Connection Report](/rest/api/power-platform/governance/cross-tenant-connection-reports/get-cross-tenant-connection-report)
+Power Platform API reference: [List Cross-Tenant Connection Reports](/rest/api/power-platform/governance/cross-tenant-connection-reports/list-cross-tenant-connection-reports)
 
 ---
 
@@ -155,7 +155,7 @@ try
 }
 ```
 
-Power Platform API reference: [List Cross-Tenant Connection Reports](/rest/api/power-platform/governance/cross-tenant-connection-reports/list-cross-tenant-connection-reports)
+Power Platform API reference: [Get Cross-Tenant Connection Report](/rest/api/power-platform/governance/cross-tenant-connection-reports/get-cross-tenant-connection-report)
 
 ---
 


### PR DESCRIPTION
Refreshes and applies the valid correction from #2701 against current `main`.

- The list-reports step now links to the List API reference.
- The single-report step now links to the Get API reference.

Closes #2701.